### PR TITLE
Add two new settings: Full Item Description On Pickup and StatsDisplay Update Interval

### DIFF
--- a/LookingGlass/BasePlugin.cs
+++ b/LookingGlass/BasePlugin.cs
@@ -98,7 +98,7 @@ namespace LookingGlass
         
         IEnumerator CheckPlayerStats()
         {
-            yield return new WaitForSeconds(.33f);
+            yield return new WaitForSeconds(StatsDisplayClass.statsDisplayUpdateInterval.Value);
             statsDisplayClass.CalculateStuff();
             StartCoroutine(CheckPlayerStats());
         }

--- a/LookingGlass/ItemStats/ItemStats.cs
+++ b/LookingGlass/ItemStats/ItemStats.cs
@@ -17,6 +17,7 @@ namespace LookingGlass.ItemStatsNameSpace
     internal class ItemStats : BaseThing
     {
         public static ConfigEntry<bool> itemStats;
+        public static ConfigEntry<bool> fullDescOnPickup;
         public static ConfigEntry<bool> itemStatsOnPing;
 
         private static Hook overrideHook;
@@ -30,13 +31,15 @@ namespace LookingGlass.ItemStatsNameSpace
         {
             InitHooks();
             ItemDefinitions.RegisterAll();
-            itemStats = BasePlugin.instance.Config.Bind<bool>("Misc", "Item Stats", true, "Shows item descriptions plus calculations");
+            itemStats = BasePlugin.instance.Config.Bind<bool>("Misc", "Item Stats", true, "Shows full item descriptions plus calculations on mouseover");
+            fullDescOnPickup = BasePlugin.instance.Config.Bind<bool>("Misc", "Full Item Description On Pickup", true, "Shows full item descriptions on pickup");
             itemStatsOnPing = BasePlugin.instance.Config.Bind<bool>("Misc", "Item Stats On Ping", true, "Shows item descriptions when you ping an item in the world");
             SetupRiskOfOptions();
         }
         public void SetupRiskOfOptions()
         {
             ModSettingsManager.AddOption(new CheckBoxOption(itemStats, new CheckBoxConfig() { restartRequired = false }));
+            ModSettingsManager.AddOption(new CheckBoxOption(fullDescOnPickup, new CheckBoxConfig() { restartRequired = false }));
             ModSettingsManager.AddOption(new CheckBoxOption(itemStatsOnPing, new CheckBoxConfig() { restartRequired = false }));
         }
         void InitHooks()
@@ -56,7 +59,7 @@ namespace LookingGlass.ItemStatsNameSpace
         void PickupText(Action<GenericNotification, ItemDef> orig, GenericNotification self, ItemDef itemDef)
         {
             orig(self, itemDef);
-            if (itemStats.Value)
+            if (fullDescOnPickup.Value)
                 self.descriptionText.token = itemDef.descriptionToken;
         }
         void ItemIndexText(Action<ItemIcon, ItemIndex, int> orig, ItemIcon self, ItemIndex newItemIndex, int newItemCount)

--- a/LookingGlass/StatsDisplay/StatsDisplayClass.cs
+++ b/LookingGlass/StatsDisplay/StatsDisplayClass.cs
@@ -21,6 +21,7 @@ namespace LookingGlass.StatsDisplay
         public static ConfigEntry<bool> statsDisplay;
         public static ConfigEntry<string> statsDisplayString;
         public static ConfigEntry<float> statsDisplaySize;
+        public static ConfigEntry<float> statsDisplayUpdateInterval;
         public static ConfigEntry<bool> builtInColors;
         public static Dictionary<string, Func<CharacterBody, string>> statDictionary = new Dictionary<string, Func<CharacterBody, string>>();
         internal static CharacterBody cachedUserBody = null;
@@ -54,6 +55,7 @@ namespace LookingGlass.StatsDisplay
                 "Max Combo: [maxCombo]"
                 , "String for the stats display. You can customize this with Unity Rich Text if you want, see \n https://docs.unity3d.com/Packages/com.unity.textmeshpro@4.0/manual/RichText.html for more info. \nAvailable syntax for the [] stuff is: \nluck \n baseDamage \n crit \n attackSpeed \n armor \n armorDamageReduction \n regen \n speed \n availableJumps \n maxJumps \n killCount \n mountainShrines \n experience \n level \n maxHealth \n maxBarrier \n barrierDecayRate \n maxShield \n acceleration \n jumpPower \n maxJumpHeight \n damage \n critMultiplier \n bleedChance \n visionDistance \n critHeal \n cursePenalty \n hasOneShotProtection \n isGlass \n canPerformBackstab \n canReceiveBackstab \n healthPercentage \n goldPortal \n msPortal \n shopPortal \n dps \n currentCombatDamage \n remainingComboDuration \n maxCombo \n critWithLuck \n bleedChanceWithLuck \n velocity \n teddyBearBlockChance \n saferSpacesCD \n instaKillChance");
             statsDisplaySize = BasePlugin.instance.Config.Bind<float>("Stats Display", "StatsDisplay font size", -1, "General font size of the stats display menu. If set to -1, will copy the font size from the objective panel");
+            statsDisplayUpdateInterval = BasePlugin.instance.Config.Bind<float>("Stats Display", "StatsDisplay update interval", 0.33f, "The interval at which stats display updates, in seconds. Lower values will increase responsiveness, but may potentially affect performance");
             builtInColors = BasePlugin.instance.Config.Bind<bool>("Stats Display", "Use default colors", true, "Uses the default styling for stats display syntax items.");
             builtInColors.SettingChanged += BuiltInColors_SettingChanged;
             StatsDisplayDefinitions.SetupDefs();
@@ -70,6 +72,7 @@ namespace LookingGlass.StatsDisplay
             ModSettingsManager.AddOption(new StringInputFieldOption(statsDisplayString, new InputFieldConfig() { restartRequired = false, lineType = TMP_InputField.LineType.MultiLineNewline, submitOn = InputFieldConfig.SubmitEnum.All }));
             ModSettingsManager.AddOption(new SliderOption(statsDisplaySize, new SliderConfig() { restartRequired = false, min = -1, max = 100 }));
             ModSettingsManager.AddOption(new CheckBoxOption(builtInColors, new CheckBoxConfig() { restartRequired = false }));
+            ModSettingsManager.AddOption(new SliderOption(statsDisplayUpdateInterval, new SliderConfig() { restartRequired = false, min = 0.05f, max = 1f, formatString = "{0:F2}s" }));
 
 
         }


### PR DESCRIPTION
This adds two new settings to the mod:

- **Full Item Description On Pickup**: This is really a separation of one setting into two separate ones. Now you can separately toggle whether you want the short or full descriptions on the item pickup notification, without losing out on the more detailed stats on the Tab screen.
- **StatsDisplay update interval**: Lets the stats update more than once every 1/3rd second. I'm guessing the low update rate was done out of an abundance of caution for performance, but having the option to make it more responsive (with a note that it may affect performance) seems like a good idea to me.

If you'd prefer me to separate these into individual PRs, I can do that, but I figured it's simplest for now to combine them.

----
also bonus fun fact: this was initially going to have four settings, but you literally added two of them (stats display font size + disabling colors) to main _while i was working on this_ so that's kinda funny (and also made my first fork branch [kind of a mess](https://github.com/SSM240/LookingGlass/commits/main/?since=2024-05-18&until=2024-05-18) which was made even more confusing when I attempted to rebase so I just abandoned that and manually transferred my changes to a new branch xd)