### PR TITLE
a few misc. StatsDisplay changes

### DIFF
--- a/LookingGlass/LookingGlass.csproj
+++ b/LookingGlass/LookingGlass.csproj
@@ -17,7 +17,7 @@
     <PackageReference Include="BepInEx.Core" Version="5.4.21" />
     <PackageReference Include="BepInEx.PluginInfoProps" Version="1.*" />
     <PackageReference Include="RiskOfRain2.GameLibs" Version="1.2.4-r.0" />
-    <PackageReference Include="Rune580-Risk_Of_Options" Version="2.7.1" />
+    <PackageReference Include="Rune580-Risk_Of_Options" Version="2.7.2" />
     <PackageReference Include="UnityEngine.Modules" Version="2019.4.26" />
   </ItemGroup>
   

--- a/LookingGlass/StatsDisplay/StatsDisplayClass.cs
+++ b/LookingGlass/StatsDisplay/StatsDisplayClass.cs
@@ -23,6 +23,8 @@ namespace LookingGlass.StatsDisplay
         public static ConfigEntry<float> statsDisplaySize;
         public static ConfigEntry<float> statsDisplayUpdateInterval;
         public static ConfigEntry<bool> builtInColors;
+        public static ConfigEntry<bool> statsDisplayOverrideHeight;
+        public static ConfigEntry<int> statsDisplayOverrideHeightValue;
         public static Dictionary<string, Func<CharacterBody, string>> statDictionary = new Dictionary<string, Func<CharacterBody, string>>();
         internal static CharacterBody cachedUserBody = null;
         Transform statTracker = null;
@@ -58,6 +60,8 @@ namespace LookingGlass.StatsDisplay
             statsDisplayUpdateInterval = BasePlugin.instance.Config.Bind<float>("Stats Display", "StatsDisplay update interval", 0.33f, "The interval at which stats display updates, in seconds. Lower values will increase responsiveness, but may potentially affect performance");
             builtInColors = BasePlugin.instance.Config.Bind<bool>("Stats Display", "Use default colors", true, "Uses the default styling for stats display syntax items.");
             builtInColors.SettingChanged += BuiltInColors_SettingChanged;
+            statsDisplayOverrideHeight = BasePlugin.instance.Config.Bind<bool>("Stats Display", "Override Stats Display Height", false, "Sets a user-specified height for Stats Display (may be necessary if you get particularly creative with formatting)");
+            statsDisplayOverrideHeightValue = BasePlugin.instance.Config.Bind<int>("Stats Display", "Stats Display Height Value", 7, "Height, in lines of full-size text, for the Stats Display panel");
             StatsDisplayDefinitions.SetupDefs();
         }
 
@@ -73,8 +77,8 @@ namespace LookingGlass.StatsDisplay
             ModSettingsManager.AddOption(new SliderOption(statsDisplaySize, new SliderConfig() { restartRequired = false, min = -1, max = 100 }));
             ModSettingsManager.AddOption(new CheckBoxOption(builtInColors, new CheckBoxConfig() { restartRequired = false }));
             ModSettingsManager.AddOption(new SliderOption(statsDisplayUpdateInterval, new SliderConfig() { restartRequired = false, min = 0.01f, max = 1f, formatString = "{0:F2}s" }));
-
-
+            ModSettingsManager.AddOption(new CheckBoxOption(statsDisplayOverrideHeight, new CheckBoxConfig() { restartRequired = false }));
+            ModSettingsManager.AddOption(new IntSliderOption(statsDisplayOverrideHeightValue, new IntSliderConfig() { restartRequired = false, min = 1, max = 100 }));
         }
         bool isRiskUI = false;
         float originalFontSize = -1;
@@ -144,16 +148,18 @@ namespace LookingGlass.StatsDisplay
                 if (textComponent && layoutElement)
                 {
                     textComponent.text = stats;
-                    int num = stats.Split('\n').Length;
+                    int nlines = (statsDisplayOverrideHeight.Value
+                        ? statsDisplayOverrideHeightValue.Value
+                        : stats.Split('\n').Length);
                     if (originalFontSize == -1)
                     {
                         originalFontSize = textComponent.fontSize;
                     }
                     textComponent.fontSize = statsDisplaySize.Value == -1 ? originalFontSize : statsDisplaySize.Value;
-                    layoutElement.preferredHeight = textComponent.fontSize * (num + 1);
+                    layoutElement.preferredHeight = textComponent.fontSize * (nlines + 1);
                     if (isRiskUI && layoutGroup)
                     {
-                        layoutGroup.padding.bottom = (int)((num / 16f) * 50);
+                        layoutGroup.padding.bottom = (int)((nlines / 16f) * 50);
                     }
                 }
                 //Log.Debug(stats);

--- a/LookingGlass/StatsDisplay/StatsDisplayClass.cs
+++ b/LookingGlass/StatsDisplay/StatsDisplayClass.cs
@@ -72,7 +72,7 @@ namespace LookingGlass.StatsDisplay
             ModSettingsManager.AddOption(new StringInputFieldOption(statsDisplayString, new InputFieldConfig() { restartRequired = false, lineType = TMP_InputField.LineType.MultiLineNewline, submitOn = InputFieldConfig.SubmitEnum.All }));
             ModSettingsManager.AddOption(new SliderOption(statsDisplaySize, new SliderConfig() { restartRequired = false, min = -1, max = 100 }));
             ModSettingsManager.AddOption(new CheckBoxOption(builtInColors, new CheckBoxConfig() { restartRequired = false }));
-            ModSettingsManager.AddOption(new SliderOption(statsDisplayUpdateInterval, new SliderConfig() { restartRequired = false, min = 0.05f, max = 1f, formatString = "{0:F2}s" }));
+            ModSettingsManager.AddOption(new SliderOption(statsDisplayUpdateInterval, new SliderConfig() { restartRequired = false, min = 0.01f, max = 1f, formatString = "{0:F2}s" }));
 
 
         }

--- a/LookingGlass/StatsDisplay/StatsDisplayClass.cs
+++ b/LookingGlass/StatsDisplay/StatsDisplayClass.cs
@@ -73,7 +73,7 @@ namespace LookingGlass.StatsDisplay
         public void SetupRiskOfOptions()
         {
             ModSettingsManager.AddOption(new CheckBoxOption(statsDisplay, new CheckBoxConfig() { restartRequired = false }));
-            ModSettingsManager.AddOption(new StringInputFieldOption(statsDisplayString, new InputFieldConfig() { restartRequired = false, lineType = TMP_InputField.LineType.MultiLineNewline, submitOn = InputFieldConfig.SubmitEnum.All }));
+            ModSettingsManager.AddOption(new StringInputFieldOption(statsDisplayString, new InputFieldConfig() { restartRequired = false, lineType = TMP_InputField.LineType.MultiLineNewline, submitOn = InputFieldConfig.SubmitEnum.All, richText = false }));
             ModSettingsManager.AddOption(new SliderOption(statsDisplaySize, new SliderConfig() { restartRequired = false, min = -1, max = 100 }));
             ModSettingsManager.AddOption(new CheckBoxOption(builtInColors, new CheckBoxConfig() { restartRequired = false }));
             ModSettingsManager.AddOption(new SliderOption(statsDisplayUpdateInterval, new SliderConfig() { restartRequired = false, min = 0.01f, max = 1f, formatString = "{0:F2}s" }));

--- a/LookingGlass/StatsDisplay/StatsDisplayClass.cs
+++ b/LookingGlass/StatsDisplay/StatsDisplayClass.cs
@@ -148,15 +148,17 @@ namespace LookingGlass.StatsDisplay
                 if (textComponent && layoutElement)
                 {
                     textComponent.text = stats;
-                    int nlines = (statsDisplayOverrideHeight.Value
+                    int nlines = statsDisplayOverrideHeight.Value
                         ? statsDisplayOverrideHeightValue.Value
-                        : stats.Split('\n').Length);
+                        : stats.Split('\n').Length;
                     if (originalFontSize == -1)
                     {
                         originalFontSize = textComponent.fontSize;
                     }
                     textComponent.fontSize = statsDisplaySize.Value == -1 ? originalFontSize : statsDisplaySize.Value;
-                    layoutElement.preferredHeight = textComponent.fontSize * (nlines + 1);
+                    layoutElement.preferredHeight = statsDisplayOverrideHeight.Value
+                        ? textComponent.fontSize * (nlines + 1)
+                        : textComponent.renderedHeight;
                     if (isRiskUI && layoutGroup)
                     {
                         layoutGroup.padding.bottom = (int)((nlines / 16f) * 50);

--- a/LookingGlass/StatsDisplay/StatsDisplayDefinitions.cs
+++ b/LookingGlass/StatsDisplay/StatsDisplayDefinitions.cs
@@ -24,7 +24,7 @@ namespace LookingGlass.StatsDisplay
             StatsDisplayClass.statDictionary.Add("armor", cachedUserBody => { return $"{healingString}{(cachedUserBody.armor)}{styleString}"; });
             StatsDisplayClass.statDictionary.Add("armorDamageReduction", cachedUserBody => { return $"{healingString}{(100 - (100 * (100 / (100 + cachedUserBody.armor)))):0.###}%{styleString}"; });
             StatsDisplayClass.statDictionary.Add("regen", cachedUserBody => { return $"{healingString}{(cachedUserBody.regen)}{styleString}"; });
-            StatsDisplayClass.statDictionary.Add("speed", cachedUserBody => { return $"{utilityString}{(cachedUserBody.moveSpeed)}{styleString}"; });
+            StatsDisplayClass.statDictionary.Add("speed", cachedUserBody => { return $"{utilityString}{(cachedUserBody.moveSpeed),6:N2}{styleString}"; });
             StatsDisplayClass.statDictionary.Add("availableJumps", cachedUserBody => { return $"{utilityString}{(cachedUserBody.maxJumpCount - cachedUserBody.characterMotor.jumpCount)}{styleString}"; });
             StatsDisplayClass.statDictionary.Add("maxJumps", cachedUserBody => { return $"{utilityString}{(cachedUserBody.maxJumpCount)}{styleString}"; });
             StatsDisplayClass.statDictionary.Add("killCount", cachedUserBody => { return $"{healthString}{(cachedUserBody.killCountServer)}{styleString}"; });
@@ -73,7 +73,7 @@ namespace LookingGlass.StatsDisplay
                 Rigidbody r = cachedUserBody.GetComponent<Rigidbody>();
                 if (r)
                 {
-                    return $"{utilityString}{r.velocity.magnitude:0.###}{styleString}";
+                    return $"{utilityString}{r.velocity.magnitude,6:N2}{styleString}";
                 }
                 return $"{utilityString}N/A{styleString}";
             });

--- a/Thunderstore/thunderstore.toml
+++ b/Thunderstore/thunderstore.toml
@@ -13,7 +13,7 @@ containsNsfwContent = false
 
 [package.dependencies]
 bbepis-BepInExPack = "5.4.2113"
-Rune580-Risk_Of_Options = "2.7.1"
+Rune580-Risk_Of_Options = "2.7.2"
 
 [build]
 icon = "icons/looking-glass-icon-static.png"


### PR DESCRIPTION
fun fact, i had velocity and update rate PRs in the works & got beaten to the punch on both counts, gg lol. gives me hope that this project is so active though. anyway, two commits that:

- let update go faster (you can see the difference on a high refresh rate monitor)
- make speed and velocity always show exactly two decimal places & have leading whitespace; this is important for `<mspace>` shenanigans which are in turn necessary for legibility if a number is changing super fast
- let you change the panel height yourself (the estimation falls flat on its face if you mix font sizes)

in combination, a format string like the following:
```
<align="center">Stats:</align>
<size=70%>
<size=80%><indent=0.75em>Speed: <pos=4em><mspace=0.5em>[speed]</mspace>
Velocity: <pos=4em><mspace=0.5em>[velocity]</mspace>
Jumps: <pos=4.5em><mspace=0.5em>[availableJumps]/[maxJumps]</mspace>
Base Damage: [baseDamage]
Attack Speed: [attackSpeed]
Crit: [critWithLuck]
Armor: [armor] | [armorDamageReduction]
Regen: [regen]
```

will get you something like this:

![statz](https://github.com/Wet-Boys/LookingGlass/assets/98245963/e176f703-5486-4e2b-89a6-5d29c09e6399)

which i think is pretty neat