### PR TITLE
Item Stats Luck Support

### DIFF
--- a/LookingGlass/ItemStats/ItemDefinitions.cs
+++ b/LookingGlass/ItemStats/ItemDefinitions.cs
@@ -1761,7 +1761,7 @@ namespace LookingGlass.ItemStatsNameSpace
             //Stone Flux Pauldron
             itemStat = new ItemStatsDef();
             itemStat.descriptions.Add("Health Bonus: ");
-            itemStat.valueTypes.Add(ItemStatsDef.ValueType.Health);
+            itemStat.valueTypes.Add(ItemStatsDef.ValueType.Healing);
             itemStat.measurementUnits.Add(ItemStatsDef.MeasurementUnits.PercentHealth);
             itemStat.descriptions.Add("MSpeed Multiplier: ");
             itemStat.valueTypes.Add(ItemStatsDef.ValueType.Utility);
@@ -2028,7 +2028,7 @@ namespace LookingGlass.ItemStatsNameSpace
             itemStat = new ItemStatsDef();
             itemStat.descriptions.Add("Sprint Healing: ");
             itemStat.valueTypes.Add(ItemStatsDef.ValueType.Healing);
-            itemStat.measurementUnits.Add(ItemStatsDef.MeasurementUnits.PercentHealth);
+            itemStat.measurementUnits.Add(ItemStatsDef.MeasurementUnits.PercentHealing);
             itemStat.calculateValues = (master, stackCount) =>
             {
                 List<float> values = new();

--- a/LookingGlass/ItemStats/ItemDefinitions.cs
+++ b/LookingGlass/ItemStats/ItemDefinitions.cs
@@ -20,6 +20,10 @@ namespace LookingGlass.ItemStatsNameSpace
             //{
             //    Log.Debug($"==========  {item}  {ItemCatalog.GetItemDef(item).nameToken}  {ItemCatalog.GetItemDef(item).name}");
             //}
+
+
+            // ---------- White Items --------------------------------------------------------------------------------
+
             //Tougher Times
             ItemStatsDef itemStat = new ItemStatsDef();
             itemStat.descriptions.Add("Block Chance: ");
@@ -27,100 +31,128 @@ namespace LookingGlass.ItemStatsNameSpace
             itemStat.measurementUnits.Add(ItemStatsDef.MeasurementUnits.Percentage);
             itemStat.calculateValues = (master, stackCount) =>
             {
-                return new List<float>([(0.15f * stackCount) / ((0.15f * stackCount) + 1)]);
+                List<float> values = new();
+                values.Add(Utils.GetHyperbolicStacking(0.15f, 0.15f, stackCount));
+                return values;
             };
-            allItemDefinitions.Add((int)ItemCatalog.FindItemIndex("Bear"), itemStat);
+            allItemDefinitions.Add((int)RoR2Content.Items.Bear.itemIndex, itemStat);
+
 
             //Armor-Piercing Rounds
             itemStat = new ItemStatsDef();
-            itemStat.descriptions.Add("Damage Increase to Bosses: ");
+            itemStat.descriptions.Add("Bonus Damage: ");
             itemStat.valueTypes.Add(ItemStatsDef.ValueType.Damage);
             itemStat.measurementUnits.Add(ItemStatsDef.MeasurementUnits.Percentage);
             itemStat.calculateValues = (master, stackCount) =>
             {
-                return new List<float>([.2f * stackCount]);
+                List<float> values = new();
+                values.Add(0.2f * stackCount);
+                return values;
             };
-            allItemDefinitions.Add((int)ItemCatalog.FindItemIndex("BossDamageBonus"), itemStat);
+            allItemDefinitions.Add((int)RoR2Content.Items.BossDamageBonus.itemIndex, itemStat);
+
 
             //Backup Magazine
-            itemStat = new ItemStatsDef();
-            itemStat.descriptions.Add("Extra Secondary Charges: ");
-            itemStat.valueTypes.Add(ItemStatsDef.ValueType.Utility);
-            itemStat.measurementUnits.Add(ItemStatsDef.MeasurementUnits.Number);
-            itemStat.calculateValues = (master, stackCount) =>
-            {
-                return new List<float>([stackCount]);
-            };
-            allItemDefinitions.Add((int)ItemCatalog.FindItemIndex("SecondarySkillMagazine"), itemStat);
+            //itemStat = new ItemStatsDef();
+            //itemStat.descriptions.Add("Skill Charges: ");
+            //itemStat.valueTypes.Add(ItemStatsDef.ValueType.Utility);
+            //itemStat.measurementUnits.Add(ItemStatsDef.MeasurementUnits.Number);
+            //itemStat.calculateValues = (master, stackCount) =>
+            //{
+            //    List<float> values = new();
+            //    values.Add(stackCount);
+            //    return values;
+            //};
+            //allItemDefinitions.Add((int)RoR2Content.Items.SecondarySkillMagazine.itemIndex, itemStat);
+
 
             //Bison Steak
             itemStat = new ItemStatsDef();
-            itemStat.descriptions.Add("Health Increase: ");
-            itemStat.valueTypes.Add(ItemStatsDef.ValueType.Healing);
-            itemStat.measurementUnits.Add(ItemStatsDef.MeasurementUnits.Health);
+            itemStat.descriptions.Add("Bonus Health: ");
+            itemStat.valueTypes.Add(ItemStatsDef.ValueType.Health);
+            itemStat.measurementUnits.Add(ItemStatsDef.MeasurementUnits.FlatHealth);
             itemStat.calculateValues = (master, stackCount) =>
             {
-                return new List<float>([stackCount * 25]);
+                List<float> values = new();
+                values.Add(25 * stackCount);
+                return values;
             };
-            allItemDefinitions.Add((int)ItemCatalog.FindItemIndex("FlatHealth"), itemStat);
+            allItemDefinitions.Add((int)RoR2Content.Items.FlatHealth.itemIndex, itemStat);
+
 
             //Bundle of Fireworks
             itemStat = new ItemStatsDef();
-            itemStat.descriptions.Add("Fireworks Launched: ");
+            itemStat.descriptions.Add("Fireworks: ");
             itemStat.valueTypes.Add(ItemStatsDef.ValueType.Damage);
             itemStat.measurementUnits.Add(ItemStatsDef.MeasurementUnits.Number);
             itemStat.calculateValues = (master, stackCount) =>
             {
-                return new List<float>([4 + (stackCount * 4)]);
+                List<float> values = new();
+                values.Add(4 + 4 * stackCount);
+                return values;
             };
-            allItemDefinitions.Add((int)ItemCatalog.FindItemIndex("Firework"), itemStat);
+            allItemDefinitions.Add((int)RoR2Content.Items.Firework.itemIndex, itemStat);
+
 
             //Bustling Fungus
             itemStat = new ItemStatsDef();
-            itemStat.descriptions.Add("hp/s: ");
+            itemStat.descriptions.Add("Healing: ");
             itemStat.valueTypes.Add(ItemStatsDef.ValueType.Healing);
-            itemStat.measurementUnits.Add(ItemStatsDef.MeasurementUnits.Percentage);
+            itemStat.measurementUnits.Add(ItemStatsDef.MeasurementUnits.PercentHealing);
             itemStat.descriptions.Add("Radius: ");
             itemStat.valueTypes.Add(ItemStatsDef.ValueType.Utility);
             itemStat.measurementUnits.Add(ItemStatsDef.MeasurementUnits.Meters);
             itemStat.calculateValues = (master, stackCount) =>
             {
-                return new List<float>([.0225f + (.0225f * stackCount), 1.5f + (1.5f * stackCount)]);
+                List<float> values = new();
+                values.Add(0.0225f + 0.0225f * stackCount);
+                values.Add(1.5f + 1.5f * stackCount);
+                return values;
             };
-            allItemDefinitions.Add((int)ItemCatalog.FindItemIndex("Mushroom"), itemStat);
+            allItemDefinitions.Add((int)RoR2Content.Items.Mushroom.itemIndex, itemStat);
+
 
             //Cautious Slug
             itemStat = new ItemStatsDef();
-            itemStat.descriptions.Add("hp/s: ");
+            itemStat.descriptions.Add("Healing: ");
             itemStat.valueTypes.Add(ItemStatsDef.ValueType.Healing);
-            itemStat.measurementUnits.Add(ItemStatsDef.MeasurementUnits.Number);
+            itemStat.measurementUnits.Add(ItemStatsDef.MeasurementUnits.FlatHealing);
             itemStat.calculateValues = (master, stackCount) =>
             {
-                return new List<float>([stackCount * 3]);
+                List<float> values = new();
+                values.Add(3f * stackCount);
+                return values;
             };
-            allItemDefinitions.Add((int)ItemCatalog.FindItemIndex("HealWhileSafe"), itemStat);
+            allItemDefinitions.Add((int)RoR2Content.Items.HealWhileSafe.itemIndex, itemStat);
+
 
             //Crowbar
             itemStat = new ItemStatsDef();
-            itemStat.descriptions.Add("Damage Increase to Healthy Enemies: ");
+            itemStat.descriptions.Add("Bonus Damage: ");
             itemStat.valueTypes.Add(ItemStatsDef.ValueType.Damage);
             itemStat.measurementUnits.Add(ItemStatsDef.MeasurementUnits.Percentage);
             itemStat.calculateValues = (master, stackCount) =>
             {
-                return new List<float>([stackCount * .75f]);
+                List<float> values = new();
+                values.Add(0.75f * stackCount);
+                return values;
             };
-            allItemDefinitions.Add((int)ItemCatalog.FindItemIndex("Crowbar"), itemStat);
+            allItemDefinitions.Add((int)RoR2Content.Items.Crowbar.itemIndex, itemStat);
+
 
             //Delicate Watch
             itemStat = new ItemStatsDef();
-            itemStat.descriptions.Add("Damage Increase: ");
+            itemStat.descriptions.Add("Bonus Damage: ");
             itemStat.valueTypes.Add(ItemStatsDef.ValueType.Damage);
             itemStat.measurementUnits.Add(ItemStatsDef.MeasurementUnits.Percentage);
             itemStat.calculateValues = (master, stackCount) =>
             {
-                return new List<float>([.2f * stackCount]);
+                List<float> values = new();
+                values.Add(0.2f * stackCount);
+                return values;
             };
-            allItemDefinitions.Add((int)ItemCatalog.FindItemIndex("FragileDamageBonus"), itemStat);
+            allItemDefinitions.Add((int)DLC1Content.Items.FragileDamageBonus.itemIndex, itemStat);
+
 
             //Energy Drink
             itemStat = new ItemStatsDef();
@@ -129,20 +161,26 @@ namespace LookingGlass.ItemStatsNameSpace
             itemStat.measurementUnits.Add(ItemStatsDef.MeasurementUnits.Percentage);
             itemStat.calculateValues = (master, stackCount) =>
             {
-                return new List<float>([.25f * stackCount]);
+                List<float> values = new();
+                values.Add(0.25f * stackCount);
+                return values;
             };
-            allItemDefinitions.Add((int)ItemCatalog.FindItemIndex("SprintBonus"), itemStat);
+            allItemDefinitions.Add((int)RoR2Content.Items.SprintBonus.itemIndex, itemStat);
+
 
             //Focus Crystal
             itemStat = new ItemStatsDef();
-            itemStat.descriptions.Add("Nearby Damage Increase: ");
+            itemStat.descriptions.Add("Bonus Damage: ");
             itemStat.valueTypes.Add(ItemStatsDef.ValueType.Damage);
             itemStat.measurementUnits.Add(ItemStatsDef.MeasurementUnits.Percentage);
             itemStat.calculateValues = (master, stackCount) =>
             {
-                return new List<float>([.2f * stackCount]);
+                List<float> values = new();
+                values.Add(0.2f * stackCount);
+                return values;
             };
-            allItemDefinitions.Add((int)ItemCatalog.FindItemIndex("NearbyDamageBonus"), itemStat);
+            allItemDefinitions.Add((int)RoR2Content.Items.NearbyDamageBonus.itemIndex, itemStat);
+
 
             //Gasoline
             itemStat = new ItemStatsDef();
@@ -157,158 +195,199 @@ namespace LookingGlass.ItemStatsNameSpace
             itemStat.measurementUnits.Add(ItemStatsDef.MeasurementUnits.Meters);
             itemStat.calculateValues = (master, stackCount) =>
             {
-                return new List<float>([2.25f + (.75f * stackCount), 1.5f + (1.5f * stackCount), 8 + (4 * stackCount)]);
+                List<float> values = new();
+                values.Add(2.25f + 0.75f * stackCount);
+                values.Add(1.5f + 1.5f * stackCount);
+                values.Add(8f + 4f * stackCount);
+                return values;
             };
-            allItemDefinitions.Add((int)ItemCatalog.FindItemIndex("IgniteOnKill"), itemStat);
+            allItemDefinitions.Add((int)RoR2Content.Items.IgniteOnKill.itemIndex, itemStat);
+
 
             //Lens-Maker's Glasses
             itemStat = new ItemStatsDef();
-            itemStat.descriptions.Add("Critical Chance Increase: ");
+            itemStat.descriptions.Add("Crit Chance: ");
             itemStat.valueTypes.Add(ItemStatsDef.ValueType.Damage);
             itemStat.measurementUnits.Add(ItemStatsDef.MeasurementUnits.Percentage);
             itemStat.calculateValues = (master, stackCount) =>
             {
-                return new List<float>([.1f * stackCount]);
+                List<float> values = new();
+                values.Add(Utils.CalculateChanceWithNullableMaster(.1f * stackCount, master));
+                return values;
             };
-            allItemDefinitions.Add((int)ItemCatalog.FindItemIndex("CritGlasses"), itemStat);
+            allItemDefinitions.Add((int)RoR2Content.Items.CritGlasses.itemIndex, itemStat);
+
 
             //Medkit
             itemStat = new ItemStatsDef();
-            itemStat.descriptions.Add("Heal Amount: <style=\"cIsHealing\">20hp</style> + ");
+            itemStat.descriptions.Add("Healing: <style=cIsHealing>20</style> + ");
             itemStat.valueTypes.Add(ItemStatsDef.ValueType.Healing);
-            itemStat.measurementUnits.Add(ItemStatsDef.MeasurementUnits.Percentage);
+            itemStat.measurementUnits.Add(ItemStatsDef.MeasurementUnits.PercentHealth);
             itemStat.calculateValues = (master, stackCount) =>
             {
-                return new List<float>([.05f * stackCount]);
+                List<float> values = new();
+                values.Add(0.05f * stackCount);
+                return values;
             };
-            allItemDefinitions.Add((int)ItemCatalog.FindItemIndex("Medkit"), itemStat);
+            allItemDefinitions.Add((int)RoR2Content.Items.Medkit.itemIndex, itemStat);
+
 
             //Mocha
             itemStat = new ItemStatsDef();
-            itemStat.descriptions.Add("Attack Speed Increase: ");
-            itemStat.valueTypes.Add(ItemStatsDef.ValueType.Utility);
+            itemStat.descriptions.Add("Attack Speed: ");
+            itemStat.valueTypes.Add(ItemStatsDef.ValueType.Damage);
             itemStat.measurementUnits.Add(ItemStatsDef.MeasurementUnits.Percentage);
-            itemStat.descriptions.Add("Movement Speed Increase: ");
+            itemStat.descriptions.Add("Movement Speed: ");
             itemStat.valueTypes.Add(ItemStatsDef.ValueType.Utility);
             itemStat.measurementUnits.Add(ItemStatsDef.MeasurementUnits.Percentage);
             itemStat.calculateValues = (master, stackCount) =>
             {
-                return new List<float>([.075f * stackCount, .07f * stackCount]);
+                List<float> values = new();
+                values.Add(0.075f * stackCount);
+                values.Add(0.07f * stackCount);
+                return values;
             };
-            allItemDefinitions.Add((int)ItemCatalog.FindItemIndex("AttackSpeedAndMoveSpeed"), itemStat);
+            allItemDefinitions.Add((int)DLC1Content.Items.AttackSpeedAndMoveSpeed.itemIndex, itemStat);
+
 
             //Monster Tooth
             itemStat = new ItemStatsDef();
-            itemStat.descriptions.Add("Heal Amount: <style=\"cIsHealing\">8hp</style> + ");
+            itemStat.descriptions.Add("Healing: <style=cIsHealing>8</style> + ");
             itemStat.valueTypes.Add(ItemStatsDef.ValueType.Healing);
-            itemStat.measurementUnits.Add(ItemStatsDef.MeasurementUnits.Percentage);
+            itemStat.measurementUnits.Add(ItemStatsDef.MeasurementUnits.PercentHealth);
             itemStat.calculateValues = (master, stackCount) =>
             {
-                return new List<float>([.02f * stackCount]);
+                List<float> values = new();
+                values.Add(0.02f * stackCount);
+                return values;
             };
-            allItemDefinitions.Add((int)ItemCatalog.FindItemIndex("Tooth"), itemStat);
+            allItemDefinitions.Add((int)RoR2Content.Items.Tooth.itemIndex, itemStat);
+
 
             //Oddly-shaped Opal
             itemStat = new ItemStatsDef();
-            itemStat.descriptions.Add("Armor Increase: ");
-            itemStat.valueTypes.Add(ItemStatsDef.ValueType.Utility);
+            itemStat.descriptions.Add("Bonus Armor: ");
+            itemStat.valueTypes.Add(ItemStatsDef.ValueType.Armor);
             itemStat.measurementUnits.Add(ItemStatsDef.MeasurementUnits.Number);
             itemStat.calculateValues = (master, stackCount) =>
             {
-                return new List<float>([100 * stackCount]);
+                List<float> values = new();
+                values.Add(100f * stackCount);
+                return values;
             };
-            allItemDefinitions.Add((int)ItemCatalog.FindItemIndex("OutOfCombatArmor"), itemStat);
+            allItemDefinitions.Add((int)DLC1Content.Items.OutOfCombatArmor.itemIndex, itemStat);
+
 
             //Paul's Goat Hoof
             itemStat = new ItemStatsDef();
-            itemStat.descriptions.Add("Movement Speed Increase: ");
+            itemStat.descriptions.Add("Movement Speed: ");
             itemStat.valueTypes.Add(ItemStatsDef.ValueType.Utility);
             itemStat.measurementUnits.Add(ItemStatsDef.MeasurementUnits.Percentage);
             itemStat.calculateValues = (master, stackCount) =>
             {
-                return new List<float>([.14f * stackCount]);
+                List<float> values = new();
+                values.Add(0.14f * stackCount);
+                return values;
             };
             allItemDefinitions.Add((int)RoR2Content.Items.Hoof.itemIndex, itemStat);
 
+
             //Personal Shield Generator
             itemStat = new ItemStatsDef();
-            itemStat.descriptions.Add("Bonus Shield: ");
+            itemStat.descriptions.Add("Shield Strength: ");
             itemStat.valueTypes.Add(ItemStatsDef.ValueType.Utility);
-            itemStat.measurementUnits.Add(ItemStatsDef.MeasurementUnits.Percentage);
+            itemStat.measurementUnits.Add(ItemStatsDef.MeasurementUnits.PercentHealth);
             itemStat.calculateValues = (master, stackCount) =>
             {
-                return new List<float>([.08f * stackCount]);
+                List<float> values = new();
+                values.Add(0.08f * stackCount);
+                return values;
             };
             allItemDefinitions.Add((int)RoR2Content.Items.PersonalShield.itemIndex, itemStat);
 
+
             //Power Elixir
-            itemStat = new ItemStatsDef();
-            itemStat.descriptions.Add("Available Charges: ");
-            itemStat.valueTypes.Add(ItemStatsDef.ValueType.Utility);
-            itemStat.measurementUnits.Add(ItemStatsDef.MeasurementUnits.Number);
-            itemStat.calculateValues = (master, stackCount) =>
-            {
-                return new List<float>([stackCount]);
-            };
-            allItemDefinitions.Add((int)ItemCatalog.FindItemIndex("HealingPotion"), itemStat);
+            //itemStat = new ItemStatsDef();
+            //itemStat.descriptions.Add("Charges: ");
+            //itemStat.valueTypes.Add(ItemStatsDef.ValueType.Utility);
+            //itemStat.measurementUnits.Add(ItemStatsDef.MeasurementUnits.Number);
+            //itemStat.calculateValues = (master, stackCount) =>
+            //{
+            //    List<float> values = new();
+            //    values.Add(stackCount);
+            //    return values;
+            //};
+            //allItemDefinitions.Add((int)DLC1Content.Items.HealingPotion.itemIndex, itemStat);
+
 
             //Repulsion Armor Plate
             itemStat = new ItemStatsDef();
             itemStat.descriptions.Add("Damage Reduction: ");
-            itemStat.valueTypes.Add(ItemStatsDef.ValueType.Utility);
+            itemStat.valueTypes.Add(ItemStatsDef.ValueType.Armor);
             itemStat.measurementUnits.Add(ItemStatsDef.MeasurementUnits.Number);
             itemStat.calculateValues = (master, stackCount) =>
             {
-                return new List<float>([5 * stackCount]);
+                List<float> values = new();
+                values.Add(5 * stackCount);
+                return values;
             };
-            allItemDefinitions.Add((int)ItemCatalog.FindItemIndex("ArmorPlate"), itemStat);
+            allItemDefinitions.Add((int)RoR2Content.Items.ArmorPlate.itemIndex, itemStat);
+
 
             //Roll of Pennies
             itemStat = new ItemStatsDef();
             itemStat.descriptions.Add("Gold Gained: ");
-            itemStat.valueTypes.Add(ItemStatsDef.ValueType.Utility);
+            itemStat.valueTypes.Add(ItemStatsDef.ValueType.Gold);
             itemStat.measurementUnits.Add(ItemStatsDef.MeasurementUnits.Number);
             itemStat.calculateValues = (master, stackCount) =>
             {
-                return new List<float>([3 * stackCount * RoR2.Run.instance.difficultyCoefficient]);
+                List<float> values = new();
+                values.Add(3 * stackCount * Run.instance.difficultyCoefficient);
+                return values;
             };
-            allItemDefinitions.Add((int)ItemCatalog.FindItemIndex("GoldOnHurt"), itemStat);
+            allItemDefinitions.Add((int)DLC1Content.Items.GoldOnHurt.itemIndex, itemStat);
 
 
             //Rusted Key
-            itemStat = new ItemStatsDef();
-            itemStat.descriptions.Add("Available Charges: ");
-            itemStat.valueTypes.Add(ItemStatsDef.ValueType.Utility);
-            itemStat.measurementUnits.Add(ItemStatsDef.MeasurementUnits.Number);
-            itemStat.calculateValues = (master, stackCount) =>
-            {
-                return new List<float>([stackCount]);
-            };
-            allItemDefinitions.Add((int)ItemCatalog.FindItemIndex("TreasureCache"), itemStat);
+            //itemStat = new ItemStatsDef();
+            //itemStat.descriptions.Add("Charges: ");
+            //itemStat.valueTypes.Add(ItemStatsDef.ValueType.Utility);
+            //itemStat.measurementUnits.Add(ItemStatsDef.MeasurementUnits.Number);
+            //itemStat.calculateValues = (master, stackCount) =>
+            //{
+            //    List<float> values = new();
+            //    values.Add(stackCount);
+            //    return values;
+            //};
+            //allItemDefinitions.Add((int)RoR2Content.Items.TreasureCache.itemIndex, itemStat);
 
 
             //Soldier's Syringe
             itemStat = new ItemStatsDef();
-            itemStat.descriptions.Add("Attack Speed Increase: ");
-            itemStat.valueTypes.Add(ItemStatsDef.ValueType.Utility);
-            itemStat.measurementUnits.Add(ItemStatsDef.MeasurementUnits.Percentage);
-            itemStat.calculateValues = (master, stackCount) =>
-            {
-                return new List<float>([.15f * stackCount]);
-            };
-            allItemDefinitions.Add((int)ItemCatalog.FindItemIndex("Syringe"), itemStat);
-
-
-            //Sticky Bomb
-            itemStat = new ItemStatsDef();
-            itemStat.descriptions.Add("Sticky Bomb Chance: ");
+            itemStat.descriptions.Add("Attack Speed: ");
             itemStat.valueTypes.Add(ItemStatsDef.ValueType.Damage);
             itemStat.measurementUnits.Add(ItemStatsDef.MeasurementUnits.Percentage);
             itemStat.calculateValues = (master, stackCount) =>
             {
-                return new List<float>([.05f * stackCount]);
+                List<float> values = new();
+                values.Add(0.15f * stackCount);
+                return values;
             };
-            allItemDefinitions.Add((int)ItemCatalog.FindItemIndex("StickyBomb"), itemStat);
+            allItemDefinitions.Add((int)RoR2Content.Items.Syringe.itemIndex, itemStat);
+
+
+            //Sticky Bomb
+            itemStat = new ItemStatsDef();
+            itemStat.descriptions.Add("Bomb Chance: ");
+            itemStat.valueTypes.Add(ItemStatsDef.ValueType.Damage);
+            itemStat.measurementUnits.Add(ItemStatsDef.MeasurementUnits.Percentage);
+            itemStat.calculateValues = (master, stackCount) =>
+            {
+                List<float> values = new();
+                values.Add(Utils.CalculateChanceWithNullableMaster(.05f * stackCount, master));
+                return values;
+            };
+            allItemDefinitions.Add((int)RoR2Content.Items.StickyBomb.itemIndex, itemStat);
 
 
             //Stun Grenade
@@ -318,21 +397,25 @@ namespace LookingGlass.ItemStatsNameSpace
             itemStat.measurementUnits.Add(ItemStatsDef.MeasurementUnits.Percentage);
             itemStat.calculateValues = (master, stackCount) =>
             {
-                return new List<float>([(0.05f * stackCount) / ((0.05f * stackCount) + 1)]);
+                List<float> values = new();
+                values.Add(Utils.CalculateChanceWithNullableMaster(Utils.GetHyperbolicStacking(0.05f, 0.05f, stackCount), master));
+                return values;
             };
-            allItemDefinitions.Add((int)ItemCatalog.FindItemIndex("StunChanceOnHit"), itemStat);
+            allItemDefinitions.Add((int)RoR2Content.Items.StunChanceOnHit.itemIndex, itemStat);
 
 
             //Topaz Brooch
             itemStat = new ItemStatsDef();
-            itemStat.descriptions.Add("Barrier Gain on Kill: ");
-            itemStat.valueTypes.Add(ItemStatsDef.ValueType.Utility);
-            itemStat.measurementUnits.Add(ItemStatsDef.MeasurementUnits.Number);
+            itemStat.descriptions.Add("Barrier On-Kill: ");
+            itemStat.valueTypes.Add(ItemStatsDef.ValueType.Healing);
+            itemStat.measurementUnits.Add(ItemStatsDef.MeasurementUnits.FlatHealth);
             itemStat.calculateValues = (master, stackCount) =>
             {
-                return new List<float>([15 * stackCount]);
+                List<float> values = new();
+                values.Add(15 * stackCount);
+                return values;
             };
-            allItemDefinitions.Add((int)ItemCatalog.FindItemIndex("BarrierOnKill"), itemStat);
+            allItemDefinitions.Add((int)RoR2Content.Items.BarrierOnKill.itemIndex, itemStat);
 
 
             //Tri-Tip Dagger
@@ -342,37 +425,45 @@ namespace LookingGlass.ItemStatsNameSpace
             itemStat.measurementUnits.Add(ItemStatsDef.MeasurementUnits.Percentage);
             itemStat.calculateValues = (master, stackCount) =>
             {
-                return new List<float>([.1f * stackCount]);
+                List<float> values = new();
+                values.Add(Utils.CalculateChanceWithNullableMaster(0.1f * stackCount, master));
+                return values;
             };
-            allItemDefinitions.Add((int)ItemCatalog.FindItemIndex("BleedOnHit"), itemStat);
+            allItemDefinitions.Add((int)RoR2Content.Items.BleedOnHit.itemIndex, itemStat);
 
 
             //Warbanner
             itemStat = new ItemStatsDef();
-            itemStat.descriptions.Add("Radius: ");
+            itemStat.descriptions.Add("Effect Radius: ");
             itemStat.valueTypes.Add(ItemStatsDef.ValueType.Utility);
             itemStat.measurementUnits.Add(ItemStatsDef.MeasurementUnits.Meters);
             itemStat.calculateValues = (master, stackCount) =>
             {
-                return new List<float>([8 + (8 * stackCount)]);
+                List<float> values = new();
+                values.Add(8 + 8 * stackCount);
+                return values;
             };
             allItemDefinitions.Add((int)RoR2Content.Items.WardOnLevel.itemIndex, itemStat);
 
 
-
-            //Green
-
+            // ---------- Green Items --------------------------------------------------------------------------------
 
             //AtG Missile Mk. 1
             itemStat = new ItemStatsDef();
+            itemStat.descriptions.Add("Fire Chance: ");
+            itemStat.valueTypes.Add(ItemStatsDef.ValueType.Utility);
+            itemStat.measurementUnits.Add(ItemStatsDef.MeasurementUnits.Percentage);
             itemStat.descriptions.Add("Damage: ");
             itemStat.valueTypes.Add(ItemStatsDef.ValueType.Damage);
             itemStat.measurementUnits.Add(ItemStatsDef.MeasurementUnits.Percentage);
             itemStat.calculateValues = (master, stackCount) =>
             {
-                return new List<float>([3 * stackCount]);
+                List<float> values = new();
+                values.Add(Utils.CalculateChanceWithNullableMaster(0.1f, master));
+                values.Add(3f * stackCount);
+                return values;
             };
-            allItemDefinitions.Add((int)ItemCatalog.FindItemIndex("Missile"), itemStat);
+            allItemDefinitions.Add((int)RoR2Content.Items.Missile.itemIndex, itemStat);
 
 
             //Bandolier
@@ -382,9 +473,11 @@ namespace LookingGlass.ItemStatsNameSpace
             itemStat.measurementUnits.Add(ItemStatsDef.MeasurementUnits.Percentage);
             itemStat.calculateValues = (master, stackCount) =>
             {
-                return new List<float>([.08f + (.1f * stackCount)]);
+                List<float> values = new();
+                values.Add(Utils.GetBandolierStacking(stackCount));
+                return values;
             };
-            allItemDefinitions.Add((int)ItemCatalog.FindItemIndex("Bandolier"), itemStat);
+            allItemDefinitions.Add((int)RoR2Content.Items.Bandolier.itemIndex, itemStat);
 
 
             //Berzerker's Pauldron
@@ -394,33 +487,39 @@ namespace LookingGlass.ItemStatsNameSpace
             itemStat.measurementUnits.Add(ItemStatsDef.MeasurementUnits.Seconds);
             itemStat.calculateValues = (master, stackCount) =>
             {
-                return new List<float>([2 + (stackCount * 4)]);
+                List<float> values = new();
+                values.Add(2 + 4 * stackCount);
+                return values;
             };
-            allItemDefinitions.Add((int)ItemCatalog.FindItemIndex("WarCryOnMultiKill"), itemStat);
+            allItemDefinitions.Add((int)RoR2Content.Items.WarCryOnMultiKill.itemIndex, itemStat);
 
 
             //Chronobauble
             itemStat = new ItemStatsDef();
-            itemStat.descriptions.Add("Debuff Duration: ");
+            itemStat.descriptions.Add("Slow Duration: ");
             itemStat.valueTypes.Add(ItemStatsDef.ValueType.Utility);
             itemStat.measurementUnits.Add(ItemStatsDef.MeasurementUnits.Seconds);
             itemStat.calculateValues = (master, stackCount) =>
             {
-                return new List<float>([2 * stackCount]);
+                List<float> values = new();
+                values.Add(2 * stackCount);
+                return values;
             };
-            allItemDefinitions.Add((int)ItemCatalog.FindItemIndex("SlowOnHit"), itemStat);
+            allItemDefinitions.Add((int)RoR2Content.Items.SlowOnHit.itemIndex, itemStat);
 
 
             //Death Mark
             itemStat = new ItemStatsDef();
-            itemStat.descriptions.Add("Debuff Duration: ");
+            itemStat.descriptions.Add("Mark Duration: ");
             itemStat.valueTypes.Add(ItemStatsDef.ValueType.Utility);
             itemStat.measurementUnits.Add(ItemStatsDef.MeasurementUnits.Seconds);
             itemStat.calculateValues = (master, stackCount) =>
             {
-                return new List<float>([7 * stackCount]);
+                List<float> values = new();
+                values.Add(7 * stackCount);
+                return values; 
             };
-            allItemDefinitions.Add((int)ItemCatalog.FindItemIndex("DeathMark"), itemStat);
+            allItemDefinitions.Add((int)RoR2Content.Items.DeathMark.itemIndex, itemStat);
 
 
             //Fuel Cell
@@ -428,14 +527,17 @@ namespace LookingGlass.ItemStatsNameSpace
             itemStat.descriptions.Add("Extra Charges: ");
             itemStat.valueTypes.Add(ItemStatsDef.ValueType.Utility);
             itemStat.measurementUnits.Add(ItemStatsDef.MeasurementUnits.Number);
-            itemStat.descriptions.Add("Equipment Cooldown Reduction: ");
+            itemStat.descriptions.Add("Cooldown Reduction: ");
             itemStat.valueTypes.Add(ItemStatsDef.ValueType.Utility);
             itemStat.measurementUnits.Add(ItemStatsDef.MeasurementUnits.Percentage);
             itemStat.calculateValues = (master, stackCount) =>
             {
-                return new List<float>([stackCount, 1 - Mathf.Pow(1 - .15f, stackCount)]);
+                List<float> values = new();
+                values.Add(stackCount);
+                values.Add(Utils.GetExponentialStacking(0.15f, 0.15f, stackCount));
+                return values;
             };
-            allItemDefinitions.Add((int)ItemCatalog.FindItemIndex("EquipmentMagazine"), itemStat);
+            allItemDefinitions.Add((int)RoR2Content.Items.EquipmentMagazine.itemIndex, itemStat);
 
 
             //Ghor's Tome
@@ -445,33 +547,39 @@ namespace LookingGlass.ItemStatsNameSpace
             itemStat.measurementUnits.Add(ItemStatsDef.MeasurementUnits.Percentage);
             itemStat.calculateValues = (master, stackCount) =>
             {
-                return new List<float>([.04f * stackCount]);
+                List<float> values = new();
+                values.Add(Utils.CalculateChanceWithNullableMaster(0.04f * stackCount, master));
+                return values;
             };
-            allItemDefinitions.Add((int)ItemCatalog.FindItemIndex("BonusGoldPackOnKill"), itemStat);
+            allItemDefinitions.Add((int)RoR2Content.Items.BonusGoldPackOnKill.itemIndex, itemStat);
 
 
             //Harvester's Scythe
             itemStat = new ItemStatsDef();
-            itemStat.descriptions.Add("Heal Amount: ");
+            itemStat.descriptions.Add("Healing: ");
             itemStat.valueTypes.Add(ItemStatsDef.ValueType.Healing);
-            itemStat.measurementUnits.Add(ItemStatsDef.MeasurementUnits.Health);
+            itemStat.measurementUnits.Add(ItemStatsDef.MeasurementUnits.FlatHealth);
             itemStat.calculateValues = (master, stackCount) =>
             {
-                return new List<float>([4 + (4 * stackCount)]);
+                List<float> values = new();
+                values.Add(4 + 4 * stackCount);
+                return values;
             };
-            allItemDefinitions.Add((int)ItemCatalog.FindItemIndex("HealOnCrit"), itemStat);
+            allItemDefinitions.Add((int)RoR2Content.Items.HealOnCrit.itemIndex, itemStat);
 
 
             //Hopoo Feather
             itemStat = new ItemStatsDef();
-            itemStat.descriptions.Add("Bonus Jumps: ");
+            itemStat.descriptions.Add("Extra Jumps: ");
             itemStat.valueTypes.Add(ItemStatsDef.ValueType.Utility);
             itemStat.measurementUnits.Add(ItemStatsDef.MeasurementUnits.Number);
             itemStat.calculateValues = (master, stackCount) =>
             {
-                return new List<float>([stackCount]);
+                List<float> values = new();
+                values.Add(stackCount);
+                return values;
             };
-            allItemDefinitions.Add((int)ItemCatalog.FindItemIndex("Feather"), itemStat);
+            allItemDefinitions.Add((int)RoR2Content.Items.Feather.itemIndex, itemStat);
 
 
             //Hunter's Harpoon
@@ -481,36 +589,43 @@ namespace LookingGlass.ItemStatsNameSpace
             itemStat.measurementUnits.Add(ItemStatsDef.MeasurementUnits.Seconds);
             itemStat.calculateValues = (master, stackCount) =>
             {
-                return new List<float>([.5f + (.5f * stackCount)]);
+                List<float> values = new();
+                values.Add(0.5f + 0.5f * stackCount);
+                return values;
             };
-            allItemDefinitions.Add((int)ItemCatalog.FindItemIndex("MoveSpeedOnKill"), itemStat);
+            allItemDefinitions.Add((int)DLC1Content.Items.MoveSpeedOnKill.itemIndex, itemStat);
 
 
             //Ignition Tank
             itemStat = new ItemStatsDef();
-            itemStat.descriptions.Add("Burn Damage Increase: ");
+            itemStat.descriptions.Add("Bonus Damage: ");
             itemStat.valueTypes.Add(ItemStatsDef.ValueType.Damage);
             itemStat.measurementUnits.Add(ItemStatsDef.MeasurementUnits.Percentage);
             itemStat.calculateValues = (master, stackCount) =>
             {
-                return new List<float>([3 * stackCount]);
+                List<float> values = new();
+                values.Add(3 * stackCount);
+                return values;
             };
-            allItemDefinitions.Add((int)ItemCatalog.FindItemIndex("StrengthenBurn"), itemStat);
+            allItemDefinitions.Add((int)DLC1Content.Items.StrengthenBurn.itemIndex, itemStat);
 
 
             //Infusion
             itemStat = new ItemStatsDef();
-            itemStat.descriptions.Add("Max Health Per Kill: ");
-            itemStat.valueTypes.Add(ItemStatsDef.ValueType.Healing);
-            itemStat.measurementUnits.Add(ItemStatsDef.MeasurementUnits.Health);
-            itemStat.descriptions.Add("Max Health Gained: ");
-            itemStat.valueTypes.Add(ItemStatsDef.ValueType.Healing);
-            itemStat.measurementUnits.Add(ItemStatsDef.MeasurementUnits.Health);
+            itemStat.descriptions.Add("Health On-Kill: ");
+            itemStat.valueTypes.Add(ItemStatsDef.ValueType.Health);
+            itemStat.measurementUnits.Add(ItemStatsDef.MeasurementUnits.FlatHealth);
+            itemStat.descriptions.Add("Max Health: ");
+            itemStat.valueTypes.Add(ItemStatsDef.ValueType.Health);
+            itemStat.measurementUnits.Add(ItemStatsDef.MeasurementUnits.FlatHealth);
             itemStat.calculateValues = (master, stackCount) =>
             {
-                return new List<float>([stackCount, 100 * stackCount]);
+                List<float> values = new();
+                values.Add(stackCount);
+                values.Add(100 * stackCount);
+                return values;
             };
-            allItemDefinitions.Add((int)ItemCatalog.FindItemIndex("Infusion"), itemStat);
+            allItemDefinitions.Add((int)RoR2Content.Items.Infusion.itemIndex, itemStat);
 
 
             //Kjaro's Band
@@ -520,86 +635,86 @@ namespace LookingGlass.ItemStatsNameSpace
             itemStat.measurementUnits.Add(ItemStatsDef.MeasurementUnits.Percentage);
             itemStat.calculateValues = (master, stackCount) =>
             {
-                return new List<float>([3 * stackCount]);
+                List<float> values = new();
+                values.Add(3 * stackCount);
+                return values;
             };
-            allItemDefinitions.Add((int)ItemCatalog.FindItemIndex("FireRing"), itemStat);
+            allItemDefinitions.Add((int)RoR2Content.Items.FireRing.itemIndex, itemStat);
 
 
             //Leeching Seed
             itemStat = new ItemStatsDef();
-            itemStat.descriptions.Add("Heal Per Hit: ");
+            itemStat.descriptions.Add("Healing On-Hit: ");
             itemStat.valueTypes.Add(ItemStatsDef.ValueType.Healing);
-            itemStat.measurementUnits.Add(ItemStatsDef.MeasurementUnits.Health);
+            itemStat.measurementUnits.Add(ItemStatsDef.MeasurementUnits.FlatHealth);
             itemStat.calculateValues = (master, stackCount) =>
             {
-                return new List<float>([stackCount]);
+                List<float> values = new();
+                values.Add(stackCount);
+                return values;
             };
-            allItemDefinitions.Add((int)ItemCatalog.FindItemIndex("Seed"), itemStat);
+            allItemDefinitions.Add((int)RoR2Content.Items.Seed.itemIndex, itemStat);
 
 
             //Lepton Daisy
             itemStat = new ItemStatsDef();
-            itemStat.descriptions.Add("Total Novas: ");
+            itemStat.descriptions.Add("Healing Novas: ");
             itemStat.valueTypes.Add(ItemStatsDef.ValueType.Healing);
-            itemStat.measurementUnits.Add(ItemStatsDef.MeasurementUnits.Health);
+            itemStat.measurementUnits.Add(ItemStatsDef.MeasurementUnits.Number);
             itemStat.calculateValues = (master, stackCount) =>
             {
-                return new List<float>([stackCount]);
+                List<float> values = new();
+                values.Add(stackCount);
+                return values;
             };
-            allItemDefinitions.Add((int)ItemCatalog.FindItemIndex("TPHealingNova"), itemStat);
+            allItemDefinitions.Add((int)RoR2Content.Items.TPHealingNova.itemIndex, itemStat);
 
 
             //Old Guillotine
             itemStat = new ItemStatsDef();
-            itemStat.descriptions.Add("InstaKill Threshhold: ");
-            itemStat.valueTypes.Add(ItemStatsDef.ValueType.Damage);
-            itemStat.measurementUnits.Add(ItemStatsDef.MeasurementUnits.Percentage);
+            itemStat.descriptions.Add("Threshold: ");
+            itemStat.valueTypes.Add(ItemStatsDef.ValueType.Health);
+            itemStat.measurementUnits.Add(ItemStatsDef.MeasurementUnits.PercentHealth);
             itemStat.calculateValues = (master, stackCount) =>
             {
-                return new List<float>([(0.13f * stackCount) / ((0.13f * stackCount) + 1)]);
+                List<float> values = new();
+                values.Add(Utils.GetHyperbolicStacking(0.13f, 0.13f, stackCount));
+                return values;
             };
-            allItemDefinitions.Add((int)ItemCatalog.FindItemIndex("ExecuteLowHealthElite"), itemStat);
+            allItemDefinitions.Add((int)RoR2Content.Items.ExecuteLowHealthElite.itemIndex, itemStat);
 
 
             //Old War Stealthkit
             itemStat = new ItemStatsDef();
-            itemStat.descriptions.Add("Recharge duration: ");
+            itemStat.descriptions.Add("Recharge Time: ");
             itemStat.valueTypes.Add(ItemStatsDef.ValueType.Utility);
             itemStat.measurementUnits.Add(ItemStatsDef.MeasurementUnits.Seconds);
             itemStat.calculateValues = (master, stackCount) =>
             {
-                return new List<float>([30 * Mathf.Pow(0.5f, stackCount - 1)]);
+                List<float> values = new();
+                values.Add(Utils.GetExponentialRechargeTime(30f, 0.5f, 0.5f, stackCount));
+                return values;
             };
-            allItemDefinitions.Add((int)ItemCatalog.FindItemIndex("Phasing"), itemStat);
+            allItemDefinitions.Add((int)RoR2Content.Items.Phasing.itemIndex, itemStat);
 
 
             //Predatory Instincts
             itemStat = new ItemStatsDef();
-            itemStat.descriptions.Add("Max Attack Speed Bonus: ");
+            itemStat.descriptions.Add("Max Attack Speed: ");
             itemStat.valueTypes.Add(ItemStatsDef.ValueType.Damage);
             itemStat.measurementUnits.Add(ItemStatsDef.MeasurementUnits.Percentage);
             itemStat.calculateValues = (master, stackCount) =>
             {
-                return new List<float>([.12f + (.24f * stackCount)]);
+                List<float> values = new();
+                values.Add(0.12f + 0.24f * stackCount);
+                return values;
             };
-            allItemDefinitions.Add((int)ItemCatalog.FindItemIndex("AttackSpeedOnCrit"), itemStat);
-
-
-            //Regenerating Scrap
-            itemStat = new ItemStatsDef();
-            itemStat.descriptions.Add("Available Charges: ");
-            itemStat.valueTypes.Add(ItemStatsDef.ValueType.Utility);
-            itemStat.measurementUnits.Add(ItemStatsDef.MeasurementUnits.Number);
-            itemStat.calculateValues = (master, stackCount) =>
-            {
-                return new List<float>([stackCount]);
-            };
-            allItemDefinitions.Add((int)ItemCatalog.FindItemIndex("RegeneratingScrap"), itemStat);
+            allItemDefinitions.Add((int)RoR2Content.Items.AttackSpeedOnCrit.itemIndex, itemStat);
 
 
             //Razorwire
             itemStat = new ItemStatsDef();
-            itemStat.descriptions.Add("Max Targets: ");
+            itemStat.descriptions.Add("Targets: ");
             itemStat.valueTypes.Add(ItemStatsDef.ValueType.Damage);
             itemStat.measurementUnits.Add(ItemStatsDef.MeasurementUnits.Meters);
             itemStat.descriptions.Add("Radius: ");
@@ -607,33 +722,54 @@ namespace LookingGlass.ItemStatsNameSpace
             itemStat.measurementUnits.Add(ItemStatsDef.MeasurementUnits.Meters);
             itemStat.calculateValues = (master, stackCount) =>
             {
-                return new List<float>([3 + (2 * stackCount), 15 + (10 * stackCount)]);
+                List<float> values = new();
+                values.Add(3 + 2 * stackCount);
+                values.Add(15 + 10 * stackCount);
+                return values;
             };
-            allItemDefinitions.Add((int)ItemCatalog.FindItemIndex("Thorns"), itemStat);
+            allItemDefinitions.Add((int)RoR2Content.Items.Thorns.itemIndex, itemStat);
 
 
             //Red Whip
             itemStat = new ItemStatsDef();
-            itemStat.descriptions.Add("Out of Combat Speed Increase: ");
+            itemStat.descriptions.Add("Speed Bonus: ");
             itemStat.valueTypes.Add(ItemStatsDef.ValueType.Utility);
             itemStat.measurementUnits.Add(ItemStatsDef.MeasurementUnits.Percentage);
             itemStat.calculateValues = (master, stackCount) =>
             {
-                return new List<float>([.3f * stackCount]);
+                List<float> values = new();
+                values.Add(0.3f * stackCount);
+                return values;
             };
-            allItemDefinitions.Add((int)ItemCatalog.FindItemIndex("SprintOutOfCombat"), itemStat);
+            allItemDefinitions.Add((int)RoR2Content.Items.SprintOutOfCombat.itemIndex, itemStat);
+
+
+            ////Regenerating Scrap
+            //itemStat = new ItemStatsDef();
+            //itemStat.descriptions.Add("Charges: ");
+            //itemStat.valueTypes.Add(ItemStatsDef.ValueType.Utility);
+            //itemStat.measurementUnits.Add(ItemStatsDef.MeasurementUnits.Number);
+            //itemStat.calculateValues = (master, stackCount) =>
+            //{
+            //    List<float> values = new();
+            //    values.Add(stackCount);
+            //    return values;
+            //};
+            //allItemDefinitions.Add((int)ItemCatalog.FindItemIndex("RegeneratingScrap"), itemStat);
 
 
             //Rose Buckler
             itemStat = new ItemStatsDef();
-            itemStat.descriptions.Add("Sprint Armor Increase: ");
-            itemStat.valueTypes.Add(ItemStatsDef.ValueType.Utility);
+            itemStat.descriptions.Add("Armor Bonus: ");
+            itemStat.valueTypes.Add(ItemStatsDef.ValueType.Armor);
             itemStat.measurementUnits.Add(ItemStatsDef.MeasurementUnits.Number);
             itemStat.calculateValues = (master, stackCount) =>
             {
-                return new List<float>([30 * stackCount]);
+                List<float> values = new();
+                values.Add(30 * stackCount);
+                return values;
             };
-            allItemDefinitions.Add((int)ItemCatalog.FindItemIndex("SprintArmor"), itemStat);
+            allItemDefinitions.Add((int)RoR2Content.Items.SprintArmor.itemIndex, itemStat);
 
 
             //Runald's Band
@@ -646,9 +782,12 @@ namespace LookingGlass.ItemStatsNameSpace
             itemStat.measurementUnits.Add(ItemStatsDef.MeasurementUnits.Percentage);
             itemStat.calculateValues = (master, stackCount) =>
             {
-                return new List<float>([3 * stackCount, 2.5f * stackCount]);
+                List<float> values = new();
+                values.Add(stackCount * 3f);
+                values.Add(stackCount * 2.5f);
+                return values;
             };
-            allItemDefinitions.Add((int)ItemCatalog.FindItemIndex("IceRing"), itemStat);
+            allItemDefinitions.Add((int)RoR2Content.Items.IceRing.itemIndex, itemStat);
 
 
             //Shipping Request Form
@@ -664,44 +803,56 @@ namespace LookingGlass.ItemStatsNameSpace
             itemStat.measurementUnits.Add(ItemStatsDef.MeasurementUnits.Percentage);
             itemStat.calculateValues = (master, stackCount) =>
             {
+                List<float> values = new();
                 float common = .79f;
                 float uncommon = .2f * stackCount;
                 float rare = .01f * Mathf.Pow(stackCount, 2);
                 float sum = common + uncommon + rare;
-                return new List<float>([common / sum, uncommon / sum, rare / sum]);
+                values.Add(common / sum);
+                values.Add(uncommon / sum);
+                values.Add(rare / sum);
+                return values;
             };
-            allItemDefinitions.Add((int)ItemCatalog.FindItemIndex("FreeChest"), itemStat);
+            allItemDefinitions.Add((int)DLC1Content.Items.FreeChest.itemIndex, itemStat);
 
 
             //Shuriken
             itemStat = new ItemStatsDef();
-            itemStat.descriptions.Add("Base Damage: ");
+            itemStat.descriptions.Add("Damage: ");
             itemStat.valueTypes.Add(ItemStatsDef.ValueType.Damage);
             itemStat.measurementUnits.Add(ItemStatsDef.MeasurementUnits.Percentage);
-            itemStat.descriptions.Add("Total Shurikens: ");
+            itemStat.descriptions.Add("Max Shurikens: ");
             itemStat.valueTypes.Add(ItemStatsDef.ValueType.Utility);
             itemStat.measurementUnits.Add(ItemStatsDef.MeasurementUnits.Number);
             itemStat.calculateValues = (master, stackCount) =>
             {
-                return new List<float>([3 + (1 * stackCount), 2 + stackCount]);
+                List<float> values = new();
+                values.Add(3 + stackCount);
+                values.Add(2 + stackCount);
+                return values;
             };
-            allItemDefinitions.Add((int)RoR2.DLC1Content.Items.PrimarySkillShuriken.itemIndex, itemStat);
+            allItemDefinitions.Add((int)DLC1Content.Items.PrimarySkillShuriken.itemIndex, itemStat);
 
 
             //Squid Polyp
             itemStat = new ItemStatsDef();
-            itemStat.descriptions.Add("Turret Attack Speed: ");
+            itemStat.descriptions.Add("Attack Speed: ");
             itemStat.valueTypes.Add(ItemStatsDef.ValueType.Damage);
             itemStat.measurementUnits.Add(ItemStatsDef.MeasurementUnits.Percentage);
             itemStat.calculateValues = (master, stackCount) =>
             {
-                return new List<float>([stackCount]);
+                List<float> values = new();
+                values.Add(stackCount);
+                return values;
             };
             allItemDefinitions.Add((int)RoR2Content.Items.Squid.itemIndex, itemStat);
 
 
             //Ukulele
             itemStat = new ItemStatsDef();
+            itemStat.descriptions.Add("Proc Chance: ");
+            itemStat.valueTypes.Add(ItemStatsDef.ValueType.Utility);
+            itemStat.measurementUnits.Add(ItemStatsDef.MeasurementUnits.Percentage);
             itemStat.descriptions.Add("Max Targets: ");
             itemStat.valueTypes.Add(ItemStatsDef.ValueType.Damage);
             itemStat.measurementUnits.Add(ItemStatsDef.MeasurementUnits.Number);
@@ -710,19 +861,25 @@ namespace LookingGlass.ItemStatsNameSpace
             itemStat.measurementUnits.Add(ItemStatsDef.MeasurementUnits.Meters);
             itemStat.calculateValues = (master, stackCount) =>
             {
-                return new List<float>([1 + (2 * stackCount), 18 + (2 * stackCount)]);
+                List<float> values = new();
+                values.Add(Utils.CalculateChanceWithNullableMaster(0.25f, master));
+                values.Add(1 + 2 * stackCount);
+                values.Add(18 + 2 * stackCount);
+                return values;
             };
             allItemDefinitions.Add((int)RoR2Content.Items.ChainLightning.itemIndex, itemStat);
 
 
             //War Horn
             itemStat = new ItemStatsDef();
-            itemStat.descriptions.Add("Buff Durations: ");
+            itemStat.descriptions.Add("Buff Duration: ");
             itemStat.valueTypes.Add(ItemStatsDef.ValueType.Damage);
             itemStat.measurementUnits.Add(ItemStatsDef.MeasurementUnits.Seconds);
             itemStat.calculateValues = (master, stackCount) =>
             {
-                return new List<float>([4 + (4 * stackCount)]);
+                List<float> values = new();
+                values.Add(4 + 4 * stackCount);
+                return values;
             };
             allItemDefinitions.Add((int)RoR2Content.Items.EnergizedOnEquipmentUse.itemIndex, itemStat);
 
@@ -734,7 +891,9 @@ namespace LookingGlass.ItemStatsNameSpace
             itemStat.measurementUnits.Add(ItemStatsDef.MeasurementUnits.Meters);
             itemStat.calculateValues = (master, stackCount) =>
             {
-                return new List<float>([10 * stackCount]);
+                List<float> values = new();
+                values.Add(10 * stackCount);
+                return values;
             };
             allItemDefinitions.Add((int)RoR2Content.Items.JumpBoost.itemIndex, itemStat);
 
@@ -744,41 +903,48 @@ namespace LookingGlass.ItemStatsNameSpace
             itemStat.descriptions.Add("Radius: ");
             itemStat.valueTypes.Add(ItemStatsDef.ValueType.Damage);
             itemStat.measurementUnits.Add(ItemStatsDef.MeasurementUnits.Meters);
-            itemStat.descriptions.Add("Base Damage: ");
+            itemStat.descriptions.Add("Pillar Damage: ");
             itemStat.valueTypes.Add(ItemStatsDef.ValueType.Damage);
             itemStat.measurementUnits.Add(ItemStatsDef.MeasurementUnits.Percentage);
             itemStat.calculateValues = (master, stackCount) =>
             {
-                return new List<float>([9.6f + (2.4f * stackCount), .7f + (2.8f * stackCount)]);
+                List<float> values = new();
+                values.Add(9.6f + (2.4f * stackCount));
+                values.Add(0.7f + (2.8f * stackCount));
+                return values;
             };
             allItemDefinitions.Add((int)RoR2Content.Items.ExplodeOnDeath.itemIndex, itemStat);
 
 
-
-
-            //RED
+            // ---------- Red Items --------------------------------------------------------------------------------
 
             //57 Leaf Clover
             itemStat = new ItemStatsDef();
-            itemStat.descriptions.Add("Rerolls: ");
+            itemStat.descriptions.Add("Luck: ");
             itemStat.valueTypes.Add(ItemStatsDef.ValueType.Utility);
             itemStat.measurementUnits.Add(ItemStatsDef.MeasurementUnits.Number);
             itemStat.calculateValues = (master, stackCount) =>
             {
-                return new List<float>([stackCount]);
+                List<float> values = new();
+                values.Add(stackCount);
+                return values;
             };
             allItemDefinitions.Add((int)RoR2Content.Items.Clover.itemIndex, itemStat);
 
+
             //Aegis HOLY SHIT XENOBLADE???
             itemStat = new ItemStatsDef();
-            itemStat.descriptions.Add("Barrier Conversion Rate: ");
+            itemStat.descriptions.Add("Healing Converted: ");
             itemStat.valueTypes.Add(ItemStatsDef.ValueType.Healing);
             itemStat.measurementUnits.Add(ItemStatsDef.MeasurementUnits.Percentage);
             itemStat.calculateValues = (master, stackCount) =>
             {
-                return new List<float>([.5f * stackCount]);
+                List<float> values = new();
+                values.Add(0.5f * stackCount);
+                return values;
             };
             allItemDefinitions.Add((int)RoR2Content.Items.BarrierOnOverHeal.itemIndex, itemStat);
+
 
             //Alien Head
             itemStat = new ItemStatsDef();
@@ -787,31 +953,40 @@ namespace LookingGlass.ItemStatsNameSpace
             itemStat.measurementUnits.Add(ItemStatsDef.MeasurementUnits.Percentage);
             itemStat.calculateValues = (master, stackCount) =>
             {
-                return new List<float>([1 - Mathf.Pow(0.75f, stackCount)]);
+                List<float> values = new();
+                values.Add(Utils.GetExponentialStacking(0.25f, 0.25f, stackCount));
+                return values;
             };
             allItemDefinitions.Add((int)RoR2Content.Items.AlienHead.itemIndex, itemStat);
 
+
             //Ben's Raincoat
             itemStat = new ItemStatsDef();
-            itemStat.descriptions.Add("Debuff Prevention Stacks: ");
+            itemStat.descriptions.Add("Debuffs Ignored: ");
             itemStat.valueTypes.Add(ItemStatsDef.ValueType.Utility);
             itemStat.measurementUnits.Add(ItemStatsDef.MeasurementUnits.Number);
             itemStat.calculateValues = (master, stackCount) =>
             {
-                return new List<float>([stackCount]);
+                List<float> values = new();
+                values.Add(stackCount);
+                return values;
             };
             allItemDefinitions.Add((int)DLC1Content.Items.ImmuneToDebuff.itemIndex, itemStat);
 
+
             //Bottled Chaos
-            itemStat = new ItemStatsDef();
-            itemStat.descriptions.Add("Random Effects: ");
-            itemStat.valueTypes.Add(ItemStatsDef.ValueType.Damage);
-            itemStat.measurementUnits.Add(ItemStatsDef.MeasurementUnits.Number);
-            itemStat.calculateValues = (master, stackCount) =>
-            {
-                return new List<float>([stackCount]);
-            };
-            allItemDefinitions.Add((int)DLC1Content.Items.RandomEquipmentTrigger.itemIndex, itemStat);
+            //itemStat = new ItemStatsDef();
+            //itemStat.descriptions.Add("Random Effects: ");
+            //itemStat.valueTypes.Add(ItemStatsDef.ValueType.Damage);
+            //itemStat.measurementUnits.Add(ItemStatsDef.MeasurementUnits.Number);
+            //itemStat.calculateValues = (master, stackCount) =>
+            //{
+            //    List<float> values = new();
+            //    values.Add(stackCount);
+            //    return values;
+            //};
+            //allItemDefinitions.Add((int)DLC1Content.Items.RandomEquipmentTrigger.itemIndex, itemStat);
+
 
             //Brainstalks
             itemStat = new ItemStatsDef();
@@ -820,9 +995,12 @@ namespace LookingGlass.ItemStatsNameSpace
             itemStat.measurementUnits.Add(ItemStatsDef.MeasurementUnits.Seconds);
             itemStat.calculateValues = (master, stackCount) =>
             {
-                return new List<float>([stackCount * 4]);
+                List<float> values = new();
+                values.Add(4 * stackCount);
+                return values;
             };
             allItemDefinitions.Add((int)RoR2Content.Items.KillEliteFrenzy.itemIndex, itemStat);
+
 
             //Brilliant Behemoth
             itemStat = new ItemStatsDef();
@@ -831,31 +1009,40 @@ namespace LookingGlass.ItemStatsNameSpace
             itemStat.measurementUnits.Add(ItemStatsDef.MeasurementUnits.Meters);
             itemStat.calculateValues = (master, stackCount) =>
             {
-                return new List<float>([1.5f + (2.5f * stackCount)]);
+                List<float> values = new();
+                values.Add(1.5f + 2.5f * stackCount);
+                return values;
             };
             allItemDefinitions.Add((int)RoR2Content.Items.Behemoth.itemIndex, itemStat);
 
+
             //Ceremonial Dagger
             itemStat = new ItemStatsDef();
-            itemStat.descriptions.Add("Dagger Base Damage: ");
+            itemStat.descriptions.Add("Dagger Damage: ");
             itemStat.valueTypes.Add(ItemStatsDef.ValueType.Damage);
             itemStat.measurementUnits.Add(ItemStatsDef.MeasurementUnits.Percentage);
             itemStat.calculateValues = (master, stackCount) =>
             {
-                return new List<float>([1.5f * stackCount]);
+                List<float> values = new();
+                values.Add(1.5f * stackCount);
+                return values;
             };
             allItemDefinitions.Add((int)RoR2Content.Items.Dagger.itemIndex, itemStat);
 
+
             //Defensive Microbots
             itemStat = new ItemStatsDef();
-            itemStat.descriptions.Add("Blocked Projectiles: ");
+            itemStat.descriptions.Add("Projectiles Blocked: ");
             itemStat.valueTypes.Add(ItemStatsDef.ValueType.Damage);
             itemStat.measurementUnits.Add(ItemStatsDef.MeasurementUnits.Number);
             itemStat.calculateValues = (master, stackCount) =>
             {
-                return new List<float>([stackCount]);
+                List<float> values = new();
+                values.Add(stackCount);
+                return values;
             };
             allItemDefinitions.Add((int)RoR2Content.Items.CaptainDefenseMatrix.itemIndex, itemStat);
+
 
             //Dio's Best Friend
             itemStat = new ItemStatsDef();
@@ -864,20 +1051,26 @@ namespace LookingGlass.ItemStatsNameSpace
             itemStat.measurementUnits.Add(ItemStatsDef.MeasurementUnits.Number);
             itemStat.calculateValues = (master, stackCount) =>
             {
-                return new List<float>([stackCount]);
+                List<float> values = new();
+                values.Add(stackCount);
+                return values;
             };
             allItemDefinitions.Add((int)RoR2Content.Items.ExtraLife.itemIndex, itemStat);
 
+
             //Frost Relic
             itemStat = new ItemStatsDef();
-            itemStat.descriptions.Add("Max Radius: ");
+            itemStat.descriptions.Add("Radius: ");
             itemStat.valueTypes.Add(ItemStatsDef.ValueType.Damage);
             itemStat.measurementUnits.Add(ItemStatsDef.MeasurementUnits.Meters);
             itemStat.calculateValues = (master, stackCount) =>
             {
-                return new List<float>([6 + (12 * stackCount)]);
+                List<float> values = new();
+                values.Add(6 + 12 * stackCount);
+                return values;
             };
             allItemDefinitions.Add((int)RoR2Content.Items.Icicle.itemIndex, itemStat);
+
 
             //H3AD-5T v2
             itemStat = new ItemStatsDef();
@@ -886,53 +1079,72 @@ namespace LookingGlass.ItemStatsNameSpace
             itemStat.measurementUnits.Add(ItemStatsDef.MeasurementUnits.Seconds);
             itemStat.calculateValues = (master, stackCount) =>
             {
-                return new List<float>([10f * Mathf.Pow(0.5f, stackCount - 1)]);
+                List<float> values = new();
+                values.Add(Utils.GetExponentialRechargeTime(10, 0.5f, 0.5f, stackCount));
+                return values;
             };
             allItemDefinitions.Add((int)RoR2Content.Items.FallBoots.itemIndex, itemStat);
 
+
             //Happiest Mask
             itemStat = new ItemStatsDef();
+            itemStat.descriptions.Add("Spawn Chance: ");
+            itemStat.valueTypes.Add(ItemStatsDef.ValueType.Utility);
+            itemStat.measurementUnits.Add(ItemStatsDef.MeasurementUnits.Percentage);
             itemStat.descriptions.Add("Ghost Duration: ");
             itemStat.valueTypes.Add(ItemStatsDef.ValueType.Damage);
             itemStat.measurementUnits.Add(ItemStatsDef.MeasurementUnits.Seconds);
             itemStat.calculateValues = (master, stackCount) =>
             {
-                return new List<float>([stackCount * 30]);
+                List<float> values = new();
+                values.Add(Utils.CalculateChanceWithNullableMaster(0.07f, master));
+                values.Add(30 * stackCount);
+                return values;
             };
             allItemDefinitions.Add((int)RoR2Content.Items.GhostOnKill.itemIndex, itemStat);
 
+
             //Hardlight Afterburner
             itemStat = new ItemStatsDef();
-            itemStat.descriptions.Add("Extra Utility Charges: ");
+            itemStat.descriptions.Add("Skill Charges: ");
             itemStat.valueTypes.Add(ItemStatsDef.ValueType.Utility);
             itemStat.measurementUnits.Add(ItemStatsDef.MeasurementUnits.Number);
             itemStat.calculateValues = (master, stackCount) =>
             {
-                return new List<float>([stackCount * 2]);
+                List<float> values = new();
+                values.Add(2 * stackCount);
+                return values;
             };
             allItemDefinitions.Add((int)RoR2Content.Items.UtilitySkillMagazine.itemIndex, itemStat);
 
+
             //Interstellar Desk Plant
             itemStat = new ItemStatsDef();
-            itemStat.descriptions.Add("Radius: ");
+            itemStat.descriptions.Add("Healing Radius: ");
             itemStat.valueTypes.Add(ItemStatsDef.ValueType.Healing);
             itemStat.measurementUnits.Add(ItemStatsDef.MeasurementUnits.Meters);
             itemStat.calculateValues = (master, stackCount) =>
             {
-                return new List<float>([5 + (5 * stackCount)]);
+                List<float> values = new();
+                values.Add(5 + 5 * stackCount);
+                return values;
             };
             allItemDefinitions.Add((int)RoR2Content.Items.Plant.itemIndex, itemStat);
 
+
             //Laser Scope
             itemStat = new ItemStatsDef();
-            itemStat.descriptions.Add("Critical Strike Bonus Damage: ");
+            itemStat.descriptions.Add("Crit Damage: ");
             itemStat.valueTypes.Add(ItemStatsDef.ValueType.Damage);
             itemStat.measurementUnits.Add(ItemStatsDef.MeasurementUnits.Percentage);
             itemStat.calculateValues = (master, stackCount) =>
             {
-                return new List<float>([stackCount]);
+                List<float> values = new();
+                values.Add(stackCount);
+                return values;
             };
             allItemDefinitions.Add((int)DLC1Content.Items.CritDamage.itemIndex, itemStat);
+
 
             //N'kuhana's Opinion
             itemStat = new ItemStatsDef();
@@ -941,20 +1153,26 @@ namespace LookingGlass.ItemStatsNameSpace
             itemStat.measurementUnits.Add(ItemStatsDef.MeasurementUnits.Percentage);
             itemStat.calculateValues = (master, stackCount) =>
             {
-                return new List<float>([stackCount]);
+                List<float> values = new();
+                values.Add(stackCount);
+                return values;
             };
             allItemDefinitions.Add((int)RoR2Content.Items.NovaOnHeal.itemIndex, itemStat);
 
+
             //Pocket I.C.B.M.
             itemStat = new ItemStatsDef();
-            itemStat.descriptions.Add("Missile Damage Increase: ");
+            itemStat.descriptions.Add("Bonus Damage: ");
             itemStat.valueTypes.Add(ItemStatsDef.ValueType.Damage);
             itemStat.measurementUnits.Add(ItemStatsDef.MeasurementUnits.Percentage);
             itemStat.calculateValues = (master, stackCount) =>
             {
-                return new List<float>([-.5f + (.5f * stackCount)]);
+                List<float> values = new();
+                values.Add(-0.5f + 0.5f * stackCount);
+                return values;
             };
             allItemDefinitions.Add((int)DLC1Content.Items.MoreMissile.itemIndex, itemStat);
+
 
             //Rejuvenation Rack
             itemStat = new ItemStatsDef();
@@ -963,9 +1181,12 @@ namespace LookingGlass.ItemStatsNameSpace
             itemStat.measurementUnits.Add(ItemStatsDef.MeasurementUnits.Percentage);
             itemStat.calculateValues = (master, stackCount) =>
             {
-                return new List<float>([stackCount]);
+                List<float> values = new();
+                values.Add(stackCount);
+                return values;
             };
             allItemDefinitions.Add((int)RoR2Content.Items.IncreaseHealing.itemIndex, itemStat);
+
 
             //Resonance Disc
             itemStat = new ItemStatsDef();
@@ -977,23 +1198,31 @@ namespace LookingGlass.ItemStatsNameSpace
             itemStat.measurementUnits.Add(ItemStatsDef.MeasurementUnits.Percentage);
             itemStat.calculateValues = (master, stackCount) =>
             {
-                return new List<float>([stackCount * 3, stackCount * 10]);
+                List<float> values = new();
+                values.Add(3 * stackCount);
+                values.Add(10 * stackCount);
+                return values;
             };
             allItemDefinitions.Add((int)RoR2Content.Items.LaserTurbine.itemIndex, itemStat);
+
 
             //Sentient Meat Hook
             itemStat = new ItemStatsDef();
             itemStat.descriptions.Add("Hook Chance: ");
-            itemStat.valueTypes.Add(ItemStatsDef.ValueType.Damage);
+            itemStat.valueTypes.Add(ItemStatsDef.ValueType.Utility);
             itemStat.measurementUnits.Add(ItemStatsDef.MeasurementUnits.Percentage);
             itemStat.descriptions.Add("Hook Damage: ");
             itemStat.valueTypes.Add(ItemStatsDef.ValueType.Damage);
             itemStat.measurementUnits.Add(ItemStatsDef.MeasurementUnits.Percentage);
             itemStat.calculateValues = (master, stackCount) =>
             {
-                return new List<float>([(0.2f * stackCount) / ((0.2f * stackCount) + 1), stackCount]);
+                List<float> values = new();
+                values.Add(Utils.CalculateChanceWithNullableMaster(Utils.GetHyperbolicStacking(0.2f, 0.2f, stackCount), master));
+                values.Add(stackCount);
+                return values;
             };
             allItemDefinitions.Add((int)RoR2Content.Items.BounceNearby.itemIndex, itemStat);
+
 
             //Shattering Justice
             itemStat = new ItemStatsDef();
@@ -1002,53 +1231,68 @@ namespace LookingGlass.ItemStatsNameSpace
             itemStat.measurementUnits.Add(ItemStatsDef.MeasurementUnits.Seconds);
             itemStat.calculateValues = (master, stackCount) =>
             {
-                return new List<float>([stackCount * 8]);
+                List<float> values = new();
+                values.Add(8 * stackCount);
+                return values;
             };
             allItemDefinitions.Add((int)RoR2Content.Items.ArmorReductionOnHit.itemIndex, itemStat);
 
+
             //Soulbound Catalyst
             itemStat = new ItemStatsDef();
-            itemStat.descriptions.Add("Reduction Amount: ");
+            itemStat.descriptions.Add("Cooldown Reduction: ");
             itemStat.valueTypes.Add(ItemStatsDef.ValueType.Utility);
             itemStat.measurementUnits.Add(ItemStatsDef.MeasurementUnits.Seconds);
             itemStat.calculateValues = (master, stackCount) =>
             {
-                return new List<float>([2 + (2 * stackCount)]);
+                List<float> values = new();
+                values.Add(2 + 2 * stackCount);
+                return values;
             };
             allItemDefinitions.Add((int)RoR2Content.Items.Talisman.itemIndex, itemStat);
 
+
             //Spare Drone Parts
             itemStat = new ItemStatsDef();
-            itemStat.descriptions.Add("Extra Drone Attack Speed: ");
+            itemStat.descriptions.Add("Drone Buff: ");
             itemStat.valueTypes.Add(ItemStatsDef.ValueType.Damage);
             itemStat.measurementUnits.Add(ItemStatsDef.MeasurementUnits.Percentage);
             itemStat.calculateValues = (master, stackCount) =>
             {
-                return new List<float>([.5f * stackCount]);
+                List<float> values = new();
+                values.Add(0.5f * stackCount);
+                return values;
             };
             allItemDefinitions.Add((int)DLC1Content.Items.DroneWeapons.itemIndex, itemStat);
 
+
             //Symbiotic Scorpion
             itemStat = new ItemStatsDef();
-            itemStat.descriptions.Add("Armor Reduction Per Hit: ");
+            itemStat.descriptions.Add("Armor Reduced On-Hit: ");
             itemStat.valueTypes.Add(ItemStatsDef.ValueType.Damage);
             itemStat.measurementUnits.Add(ItemStatsDef.MeasurementUnits.Number);
             itemStat.calculateValues = (master, stackCount) =>
             {
-                return new List<float>([stackCount * 2]);
+                List<float> values = new();
+                values.Add(2 * stackCount);
+                return values;
             };
             allItemDefinitions.Add((int)DLC1Content.Items.PermanentDebuffOnHit.itemIndex, itemStat);
 
+
             //Unstable Tesla Coil
             itemStat = new ItemStatsDef();
-            itemStat.descriptions.Add("Max Enemies Hit: ");
+            itemStat.descriptions.Add("Max Targets: ");
             itemStat.valueTypes.Add(ItemStatsDef.ValueType.Damage);
             itemStat.measurementUnits.Add(ItemStatsDef.MeasurementUnits.Number);
             itemStat.calculateValues = (master, stackCount) =>
             {
-                return new List<float>([1 + (2 * stackCount)]);
+                List<float> values = new();
+                values.Add(1 + 2 * stackCount);
+                return values;
             };
             allItemDefinitions.Add((int)RoR2Content.Items.ShockNearby.itemIndex, itemStat);
+
 
             //Wake of Vultures
             itemStat = new ItemStatsDef();
@@ -1057,23 +1301,32 @@ namespace LookingGlass.ItemStatsNameSpace
             itemStat.measurementUnits.Add(ItemStatsDef.MeasurementUnits.Seconds);
             itemStat.calculateValues = (master, stackCount) =>
             {
-                return new List<float>([3 + (stackCount * 5)]);
+                List<float> values = new();
+                values.Add(3 + 5 * stackCount);
+                return values;
             };
             allItemDefinitions.Add((int)RoR2Content.Items.HeadHunter.itemIndex, itemStat);
 
 
-            //Boss
+            // ---------- Boss Items --------------------------------------------------------------------------------
 
             //Charged Perforator
             itemStat = new ItemStatsDef();
+            itemStat.descriptions.Add("Proc Chance: ");
+            itemStat.valueTypes.Add(ItemStatsDef.ValueType.Utility);
+            itemStat.measurementUnits.Add(ItemStatsDef.MeasurementUnits.Percentage);
             itemStat.descriptions.Add("Damage: ");
             itemStat.valueTypes.Add(ItemStatsDef.ValueType.Damage);
             itemStat.measurementUnits.Add(ItemStatsDef.MeasurementUnits.Percentage);
             itemStat.calculateValues = (master, stackCount) =>
             {
-                return new List<float>([stackCount * 5]);
+                List<float> values = new();
+                values.Add(Utils.CalculateChanceWithNullableMaster(0.1f, master));
+                values.Add(5 * stackCount);
+                return values;
             };
             allItemDefinitions.Add((int)RoR2Content.Items.LightningStrikeOnHit.itemIndex, itemStat);
+
 
             //Defense Nucleus
             itemStat = new ItemStatsDef();
@@ -1082,20 +1335,26 @@ namespace LookingGlass.ItemStatsNameSpace
             itemStat.measurementUnits.Add(ItemStatsDef.MeasurementUnits.Number);
             itemStat.calculateValues = (master, stackCount) =>
             {
-                return new List<float>([stackCount * 4]);
+                List<float> values = new();
+                values.Add(4 * stackCount);
+                return values;
             };
             allItemDefinitions.Add((int)DLC1Content.Items.MinorConstructOnKill.itemIndex, itemStat);
 
+
             //Empathy Cores
             itemStat = new ItemStatsDef();
-            itemStat.descriptions.Add("Core Base Damage: ");
+            itemStat.descriptions.Add("Damage Per Ally: ");
             itemStat.valueTypes.Add(ItemStatsDef.ValueType.Damage);
             itemStat.measurementUnits.Add(ItemStatsDef.MeasurementUnits.Percentage);
             itemStat.calculateValues = (master, stackCount) =>
             {
-                return new List<float>([stackCount]);
+                List<float> values = new();
+                values.Add(stackCount);
+                return values;
             };
             allItemDefinitions.Add((int)RoR2Content.Items.RoboBallBuddy.itemIndex, itemStat);
+
 
             //Genesis Loop
             itemStat = new ItemStatsDef();
@@ -1104,9 +1363,12 @@ namespace LookingGlass.ItemStatsNameSpace
             itemStat.measurementUnits.Add(ItemStatsDef.MeasurementUnits.Seconds);
             itemStat.calculateValues = (master, stackCount) =>
             {
-                return new List<float>([30 / (1 + stackCount)]);
+                List<float> values = new();
+                values.Add(30 / (1 + stackCount));
+                return values;
             };
             allItemDefinitions.Add((int)RoR2Content.Items.NovaOnLowHealth.itemIndex, itemStat);
+
 
             //Halcyon Seed
             itemStat = new ItemStatsDef();
@@ -1118,20 +1380,27 @@ namespace LookingGlass.ItemStatsNameSpace
             itemStat.measurementUnits.Add(ItemStatsDef.MeasurementUnits.Percentage);
             itemStat.calculateValues = (master, stackCount) =>
             {
-                return new List<float>([.5f + (.5f * stackCount), stackCount]);
+                List<float> values = new();
+                values.Add(0.5f + 0.5f * stackCount);
+                values.Add(stackCount);
+                return values;
             };
             allItemDefinitions.Add((int)RoR2Content.Items.TitanGoldDuringTP.itemIndex, itemStat);
 
+
             //Irradiant Pearl
             itemStat = new ItemStatsDef();
-            itemStat.descriptions.Add("Stat Increase: ");
+            itemStat.descriptions.Add("All Stats: ");
             itemStat.valueTypes.Add(ItemStatsDef.ValueType.Utility);
             itemStat.measurementUnits.Add(ItemStatsDef.MeasurementUnits.Percentage);
             itemStat.calculateValues = (master, stackCount) =>
             {
-                return new List<float>([.1f * stackCount]);
+                List<float> values = new();
+                values.Add(0.1f * stackCount);
+                return values;
             };
             allItemDefinitions.Add((int)RoR2Content.Items.ShinyPearl.itemIndex, itemStat);
+
 
             //Little Disciple
             itemStat = new ItemStatsDef();
@@ -1140,95 +1409,124 @@ namespace LookingGlass.ItemStatsNameSpace
             itemStat.measurementUnits.Add(ItemStatsDef.MeasurementUnits.Percentage);
             itemStat.calculateValues = (master, stackCount) =>
             {
-                return new List<float>([stackCount * 3]);
+                List<float> values = new();
+                values.Add(3f * stackCount);
+                return values;
             };
             allItemDefinitions.Add((int)RoR2Content.Items.SprintWisp.itemIndex, itemStat);
 
+
             //Mired Urn
             itemStat = new ItemStatsDef();
-            itemStat.descriptions.Add("Tethered Entities: ");
-            itemStat.valueTypes.Add(ItemStatsDef.ValueType.Utility);
+            itemStat.descriptions.Add("Tethers: ");
+            itemStat.valueTypes.Add(ItemStatsDef.ValueType.Healing);
             itemStat.measurementUnits.Add(ItemStatsDef.MeasurementUnits.Number);
             itemStat.calculateValues = (master, stackCount) =>
             {
-                return new List<float>([stackCount]);
+                List<float> values = new();
+                values.Add(stackCount);
+                return values;
             };
             allItemDefinitions.Add((int)RoR2Content.Items.SiphonOnLowHealth.itemIndex, itemStat);
 
+
             //Molten Perforator
             itemStat = new ItemStatsDef();
-            itemStat.descriptions.Add("Magma Ball Damage: ");
+            itemStat.descriptions.Add("Proc Chance: ");
+            itemStat.valueTypes.Add(ItemStatsDef.ValueType.Utility);
+            itemStat.measurementUnits.Add(ItemStatsDef.MeasurementUnits.Percentage);
+            itemStat.descriptions.Add("Damage: ");
             itemStat.valueTypes.Add(ItemStatsDef.ValueType.Damage);
             itemStat.measurementUnits.Add(ItemStatsDef.MeasurementUnits.Percentage);
             itemStat.calculateValues = (master, stackCount) =>
             {
-                return new List<float>([stackCount * 3]);
+                List<float> values = new();
+                values.Add(Utils.CalculateChanceWithNullableMaster(0.1f, master));
+                values.Add(3 * stackCount);
+                return values;
             };
             allItemDefinitions.Add((int)RoR2Content.Items.FireballsOnHit.itemIndex, itemStat);
 
+
             //Pearl
             itemStat = new ItemStatsDef();
-            itemStat.descriptions.Add("Health Increase: ");
-            itemStat.valueTypes.Add(ItemStatsDef.ValueType.Healing);
-            itemStat.measurementUnits.Add(ItemStatsDef.MeasurementUnits.Percentage);
+            itemStat.descriptions.Add("Health Bonus: ");
+            itemStat.valueTypes.Add(ItemStatsDef.ValueType.Health);
+            itemStat.measurementUnits.Add(ItemStatsDef.MeasurementUnits.PercentHealth);
             itemStat.calculateValues = (master, stackCount) =>
             {
-                return new List<float>([.1f * stackCount]);
+                List<float> values = new();
+                values.Add(0.1f * stackCount);
+                return values;
             };
             allItemDefinitions.Add((int)RoR2Content.Items.Pearl.itemIndex, itemStat);
 
+
             //Planula
             itemStat = new ItemStatsDef();
-            itemStat.descriptions.Add("Amount Healed: ");
+            itemStat.descriptions.Add("Healing: ");
             itemStat.valueTypes.Add(ItemStatsDef.ValueType.Healing);
-            itemStat.measurementUnits.Add(ItemStatsDef.MeasurementUnits.Health);
+            itemStat.measurementUnits.Add(ItemStatsDef.MeasurementUnits.FlatHealth);
             itemStat.calculateValues = (master, stackCount) =>
             {
-                return new List<float>([stackCount * 15]);
+                List<float> values = new();
+                values.Add(15 * stackCount);
+                return values;
             };
             allItemDefinitions.Add((int)RoR2Content.Items.ParentEgg.itemIndex, itemStat);
 
+
             //Queen's Gland
             itemStat = new ItemStatsDef();
-            itemStat.descriptions.Add("Beetle Guard Count: ");
+            itemStat.descriptions.Add("Beetle Guards: ");
             itemStat.valueTypes.Add(ItemStatsDef.ValueType.Utility);
             itemStat.measurementUnits.Add(ItemStatsDef.MeasurementUnits.Number);
             itemStat.calculateValues = (master, stackCount) =>
             {
-                return new List<float>([stackCount]);
+                List<float> values = new();
+                values.Add(stackCount);
+                return values;
             };
             allItemDefinitions.Add((int)RoR2Content.Items.BeetleGland.itemIndex, itemStat);
+
 
             //Shatterspleen
             itemStat = new ItemStatsDef();
             itemStat.descriptions.Add("Explosion Base Damage: ");
             itemStat.valueTypes.Add(ItemStatsDef.ValueType.Damage);
             itemStat.measurementUnits.Add(ItemStatsDef.MeasurementUnits.Percentage);
-            itemStat.descriptions.Add("Explosion Health% Damage: ");
+            itemStat.descriptions.Add("Explosion Scaling: ");
             itemStat.valueTypes.Add(ItemStatsDef.ValueType.Damage);
-            itemStat.measurementUnits.Add(ItemStatsDef.MeasurementUnits.Percentage);
+            itemStat.measurementUnits.Add(ItemStatsDef.MeasurementUnits.PercentHealth);
             itemStat.calculateValues = (master, stackCount) =>
             {
-                return new List<float>([4 * stackCount, .15f * stackCount]);
+                List<float> values = new();
+                values.Add(4 * stackCount);
+                values.Add(0.15f * stackCount);
+                return values;
             };
             allItemDefinitions.Add((int)RoR2Content.Items.BleedOnHitAndExplode.itemIndex, itemStat);
 
+
             //Titanic Knurl
             itemStat = new ItemStatsDef();
-            itemStat.descriptions.Add("Max Health Increase: ");
+            itemStat.descriptions.Add("Bonus Health: ");
+            itemStat.valueTypes.Add(ItemStatsDef.ValueType.Health);
+            itemStat.measurementUnits.Add(ItemStatsDef.MeasurementUnits.FlatHealth);
+            itemStat.descriptions.Add("Healing: ");
             itemStat.valueTypes.Add(ItemStatsDef.ValueType.Healing);
-            itemStat.measurementUnits.Add(ItemStatsDef.MeasurementUnits.Health);
-            itemStat.descriptions.Add("hp/s Increase: ");
-            itemStat.valueTypes.Add(ItemStatsDef.ValueType.Healing);
-            itemStat.measurementUnits.Add(ItemStatsDef.MeasurementUnits.Number);
+            itemStat.measurementUnits.Add(ItemStatsDef.MeasurementUnits.FlatHealing);
             itemStat.calculateValues = (master, stackCount) =>
             {
-                return new List<float>([stackCount * 40, stackCount * 1.6f]);
+                List<float> values = new();
+                values.Add(40 * stackCount);
+                values.Add(1.6f * stackCount);
+                return values;
             };
             allItemDefinitions.Add((int)RoR2Content.Items.Knurl.itemIndex, itemStat);
 
 
-            //why are you blue
+            // ---------- why are you blue --------------------------------------------------------------------------------
 
             //Beads of Fealty
             itemStat = new ItemStatsDef();
@@ -1237,48 +1535,60 @@ namespace LookingGlass.ItemStatsNameSpace
             itemStat.measurementUnits.Add(ItemStatsDef.MeasurementUnits.Number);
             itemStat.calculateValues = (master, stackCount) =>
             {
-                return new List<float>([stackCount]);
+                List<float> values = new();
+                values.Add(stackCount);
+                return values;
             };
             allItemDefinitions.Add((int)RoR2Content.Items.LunarTrinket.itemIndex, itemStat);
+
 
             //Brittle Crown
             itemStat = new ItemStatsDef();
             itemStat.descriptions.Add("Gold Gained: ");
-            itemStat.valueTypes.Add(ItemStatsDef.ValueType.Utility);
+            itemStat.valueTypes.Add(ItemStatsDef.ValueType.Gold);
             itemStat.measurementUnits.Add(ItemStatsDef.MeasurementUnits.Number);
             itemStat.descriptions.Add("Gold Lost: ");
             itemStat.valueTypes.Add(ItemStatsDef.ValueType.Health);
             itemStat.measurementUnits.Add(ItemStatsDef.MeasurementUnits.Percentage);
             itemStat.calculateValues = (master, stackCount) =>
             {
-                return new List<float>([stackCount * 2 * RoR2.Run.instance.difficultyCoefficient, stackCount]);
+                List<float> values = new();
+                values.Add(2 * stackCount * Run.instance.difficultyCoefficient);
+                values.Add(stackCount);
+                return values;
             };
             allItemDefinitions.Add((int)RoR2Content.Items.GoldOnHit.itemIndex, itemStat);
 
+
             //Corpsebloom
             itemStat = new ItemStatsDef();
-            itemStat.descriptions.Add("Heal Bonus: ");
+            itemStat.descriptions.Add("Bonus Healing: ");
             itemStat.valueTypes.Add(ItemStatsDef.ValueType.Healing);
             itemStat.measurementUnits.Add(ItemStatsDef.MeasurementUnits.Percentage);
-            itemStat.descriptions.Add("Max Healing Per Second: ");
+            itemStat.descriptions.Add("Healing Cap: ");
             itemStat.valueTypes.Add(ItemStatsDef.ValueType.Healing);
-            itemStat.measurementUnits.Add(ItemStatsDef.MeasurementUnits.Percentage);
+            itemStat.measurementUnits.Add(ItemStatsDef.MeasurementUnits.PercentHealing);
             itemStat.calculateValues = (master, stackCount) =>
             {
-                return new List<float>([stackCount, .1f * (1/stackCount)]);
+                List<float> values = new();
+                values.Add(stackCount);
+                values.Add(0.1f * 1 / stackCount);
+                return values;
             };
             allItemDefinitions.Add((int)RoR2Content.Items.RepeatHeal.itemIndex, itemStat);
 
+
             //Defiant Gouge
-            itemStat = new ItemStatsDef();
-            itemStat.descriptions.Add("Enemy Strength: ");
-            itemStat.valueTypes.Add(ItemStatsDef.ValueType.Utility);
-            itemStat.measurementUnits.Add(ItemStatsDef.MeasurementUnits.Number);
-            itemStat.calculateValues = (master, stackCount) =>
-            {
-                return new List<float>([stackCount]);
-            };
-            allItemDefinitions.Add((int)RoR2Content.Items.MonstersOnShrineUse.itemIndex, itemStat);
+            //itemStat = new ItemStatsDef();
+            //itemStat.descriptions.Add("Enemy Strength: ");
+            //itemStat.valueTypes.Add(ItemStatsDef.ValueType.Utility);
+            //itemStat.measurementUnits.Add(ItemStatsDef.MeasurementUnits.Number);
+            //itemStat.calculateValues = (master, stackCount) =>
+            //{
+            //    return new List<float>([stackCount]);
+            //};
+            //allItemDefinitions.Add((int)RoR2Content.Items.MonstersOnShrineUse.itemIndex, itemStat);
+
 
             //Egocentrism
             itemStat = new ItemStatsDef();
@@ -1290,13 +1600,17 @@ namespace LookingGlass.ItemStatsNameSpace
             itemStat.measurementUnits.Add(ItemStatsDef.MeasurementUnits.Number);
             itemStat.calculateValues = (master, stackCount) =>
             {
-                return new List<float>([3 * (1 / stackCount), 2 + stackCount]);
+                List<float> values = new();
+                values.Add(3 * 1 / stackCount);
+                values.Add(2 + stackCount);
+                return values;
             };
             allItemDefinitions.Add((int)DLC1Content.Items.LunarSun.itemIndex, itemStat);
 
+
             //Essence of Heresy
             itemStat = new ItemStatsDef();
-            itemStat.descriptions.Add("Stack Duration: ");
+            itemStat.descriptions.Add("Ruin Duration: ");
             itemStat.valueTypes.Add(ItemStatsDef.ValueType.Damage);
             itemStat.measurementUnits.Add(ItemStatsDef.MeasurementUnits.Seconds);
             itemStat.descriptions.Add("Recharge Time: ");
@@ -1304,9 +1618,13 @@ namespace LookingGlass.ItemStatsNameSpace
             itemStat.measurementUnits.Add(ItemStatsDef.MeasurementUnits.Seconds);
             itemStat.calculateValues = (master, stackCount) =>
             {
-                return new List<float>([stackCount * 10, stackCount * 8]);
+                List<float> values = new();
+                values.Add(10 * stackCount);
+                values.Add(8 * stackCount);
+                return values;
             };
             allItemDefinitions.Add((int)RoR2Content.Items.LunarSpecialReplacement.itemIndex, itemStat);
+
 
             //Eulogy Zero
             itemStat = new ItemStatsDef();
@@ -1315,13 +1633,16 @@ namespace LookingGlass.ItemStatsNameSpace
             itemStat.measurementUnits.Add(ItemStatsDef.MeasurementUnits.Percentage);
             itemStat.calculateValues = (master, stackCount) =>
             {
-                return new List<float>([.05f * stackCount]);
+                List<float> values = new();
+                values.Add(Utils.CalculateChanceWithNullableMaster(0.05f * stackCount, master));
+                return values;
             };
             allItemDefinitions.Add((int)DLC1Content.Items.RandomlyLunar.itemIndex, itemStat);
 
+
             //Focused Convergence
             itemStat = new ItemStatsDef();
-            itemStat.descriptions.Add("Charge Time: ");
+            itemStat.descriptions.Add("Charging Time: ");
             itemStat.valueTypes.Add(ItemStatsDef.ValueType.Utility);
             itemStat.measurementUnits.Add(ItemStatsDef.MeasurementUnits.Seconds);
             itemStat.descriptions.Add("Zone Size: ");
@@ -1329,20 +1650,27 @@ namespace LookingGlass.ItemStatsNameSpace
             itemStat.measurementUnits.Add(ItemStatsDef.MeasurementUnits.Percentage);
             itemStat.calculateValues = (master, stackCount) =>
             {
-                return new List<float>([90f / (1f + 0.3f * Mathf.Min(stackCount, 3f)), 1 / (2 * Mathf.Min(stackCount, 3f))]);
+                List<float> values = new();
+                values.Add(90f / (1f + 0.3f * Mathf.Min(stackCount, 3)));
+                values.Add(1.0f / 2 * Mathf.Min(stackCount, 3));
+                return values;
             };
             allItemDefinitions.Add((int)RoR2Content.Items.FocusConvergence.itemIndex, itemStat);
 
+
             //Gesture of the Drowned
             itemStat = new ItemStatsDef();
-            itemStat.descriptions.Add("Equipment Cooldown: ");
+            itemStat.descriptions.Add("Cooldown Reduction: ");
             itemStat.valueTypes.Add(ItemStatsDef.ValueType.Utility);
             itemStat.measurementUnits.Add(ItemStatsDef.MeasurementUnits.Percentage);
             itemStat.calculateValues = (master, stackCount) =>
             {
-                return new List<float>([1f - (0.5f * Mathf.Pow(0.85f, stackCount - 1))]);
+                List<float> values = new();
+                values.Add(Utils.GetExponentialStacking(0.5f, 0.15f, stackCount));
+                return values;
             };
             allItemDefinitions.Add((int)RoR2Content.Items.AutoCastEquipment.itemIndex, itemStat);
+
 
             //Hooks of Heresy
             itemStat = new ItemStatsDef();
@@ -1354,105 +1682,135 @@ namespace LookingGlass.ItemStatsNameSpace
             itemStat.measurementUnits.Add(ItemStatsDef.MeasurementUnits.Seconds);
             itemStat.calculateValues = (master, stackCount) =>
             {
-                return new List<float>([stackCount * 3, stackCount * 5]);
+                List<float> values = new();
+                values.Add(3 * stackCount);
+                values.Add(5 * stackCount);
+                return values;
             };
             allItemDefinitions.Add((int)RoR2Content.Items.LunarSecondaryReplacement.itemIndex, itemStat);
 
+
             //Light Flux Pauldron
             itemStat = new ItemStatsDef();
-            itemStat.descriptions.Add("Skill Cooldown: ");
+            itemStat.descriptions.Add("Cooldown Reduction: ");
             itemStat.valueTypes.Add(ItemStatsDef.ValueType.Utility);
             itemStat.measurementUnits.Add(ItemStatsDef.MeasurementUnits.Percentage);
-            itemStat.descriptions.Add("Attack Speed Reduction: ");
+            itemStat.descriptions.Add("Attack Speed Multiplier: ");
             itemStat.valueTypes.Add(ItemStatsDef.ValueType.Damage);
             itemStat.measurementUnits.Add(ItemStatsDef.MeasurementUnits.Percentage);
             itemStat.calculateValues = (master, stackCount) =>
             {
-                return new List<float>([Mathf.Pow(.5f, stackCount), 1 / (stackCount + 1)]);
+                List<float> values = new();
+                values.Add(Utils.GetExponentialStacking(0.5f, 0.5f, stackCount));
+                values.Add(1 / (1 + stackCount));
+                return values;
             };
             allItemDefinitions.Add((int)DLC1Content.Items.HalfAttackSpeedHalfCooldowns.itemIndex, itemStat);
 
+
             //Mercurial Rachis
             itemStat = new ItemStatsDef();
-            itemStat.descriptions.Add("Radius: ");
+            itemStat.descriptions.Add("Ward Radius: ");
             itemStat.valueTypes.Add(ItemStatsDef.ValueType.Utility);
             itemStat.measurementUnits.Add(ItemStatsDef.MeasurementUnits.Meters);
             itemStat.calculateValues = (master, stackCount) =>
             {
-                return new List<float>([16f * Mathf.Pow(1.5f, stackCount - 1)]);
+                List<float> values = new();
+                values.Add(16 * Mathf.Pow(1.5f, stackCount - 1));
+                return values;
             };
             allItemDefinitions.Add((int)RoR2Content.Items.RandomDamageZone.itemIndex, itemStat);
 
+
             //Purity
             itemStat = new ItemStatsDef();
-            itemStat.descriptions.Add("Skill Cooldown Reduction: ");
+            itemStat.descriptions.Add("Cooldown Reduction: ");
             itemStat.valueTypes.Add(ItemStatsDef.ValueType.Utility);
             itemStat.measurementUnits.Add(ItemStatsDef.MeasurementUnits.Seconds);
-            itemStat.descriptions.Add("Negative Luck: ");
-            itemStat.valueTypes.Add(ItemStatsDef.ValueType.Health);
+            itemStat.descriptions.Add("Luck: ");
+            itemStat.valueTypes.Add(ItemStatsDef.ValueType.Death);
             itemStat.measurementUnits.Add(ItemStatsDef.MeasurementUnits.Number);
             itemStat.calculateValues = (master, stackCount) =>
             {
-                return new List<float>([stackCount + 1, stackCount]);
+                List<float> values = new();
+                values.Add(stackCount + 1);
+                values.Add(-stackCount);
+                return values;
             };
             allItemDefinitions.Add((int)RoR2Content.Items.LunarBadLuck.itemIndex, itemStat);
 
+
             //Shaped Glass
             itemStat = new ItemStatsDef();
-            itemStat.descriptions.Add("Total Damage: ");
+            itemStat.descriptions.Add("Damage Multiplier: ");
             itemStat.valueTypes.Add(ItemStatsDef.ValueType.Damage);
             itemStat.measurementUnits.Add(ItemStatsDef.MeasurementUnits.Percentage);
-            itemStat.descriptions.Add("Total Health: ");
-            itemStat.valueTypes.Add(ItemStatsDef.ValueType.Healing);
+            itemStat.descriptions.Add("Health Multiplier: ");
+            itemStat.valueTypes.Add(ItemStatsDef.ValueType.Health);
             itemStat.measurementUnits.Add(ItemStatsDef.MeasurementUnits.Percentage);
             itemStat.calculateValues = (master, stackCount) =>
             {
-                return new List<float>([Mathf.Pow(2, stackCount), Mathf.Pow(.5f, stackCount)]);
+                List<float> values = new();
+                values.Add(Mathf.Pow(2f, stackCount));
+                values.Add(Mathf.Pow(0.5f, stackCount));
+                return values;
             };
             allItemDefinitions.Add((int)RoR2Content.Items.LunarDagger.itemIndex, itemStat);
 
+
             //Stone Flux Pauldron
             itemStat = new ItemStatsDef();
-            itemStat.descriptions.Add("Health Increase: ");
-            itemStat.valueTypes.Add(ItemStatsDef.ValueType.Healing);
-            itemStat.measurementUnits.Add(ItemStatsDef.MeasurementUnits.Percentage);
-            itemStat.descriptions.Add("Movement Decrease: ");
+            itemStat.descriptions.Add("Health Bonus: ");
+            itemStat.valueTypes.Add(ItemStatsDef.ValueType.Health);
+            itemStat.measurementUnits.Add(ItemStatsDef.MeasurementUnits.PercentHealth);
+            itemStat.descriptions.Add("MSpeed Multiplier: ");
             itemStat.valueTypes.Add(ItemStatsDef.ValueType.Utility);
             itemStat.measurementUnits.Add(ItemStatsDef.MeasurementUnits.Percentage);
             itemStat.calculateValues = (master, stackCount) =>
             {
-                return new List<float>([stackCount, 1 / (1 + stackCount)]);
+                List<float> values = new();
+                values.Add(stackCount);
+                values.Add(1 / (1 + stackCount));
+                return values;
             };
             allItemDefinitions.Add((int)DLC1Content.Items.HalfSpeedDoubleHealth.itemIndex, itemStat);
 
+
             //Strides of Heresy
             itemStat = new ItemStatsDef();
-            itemStat.descriptions.Add("Heal Amount: ");
+            itemStat.descriptions.Add("Healing: ");
             itemStat.valueTypes.Add(ItemStatsDef.ValueType.Healing);
-            itemStat.measurementUnits.Add(ItemStatsDef.MeasurementUnits.Percentage);
-            itemStat.descriptions.Add("Duration: ");
+            itemStat.measurementUnits.Add(ItemStatsDef.MeasurementUnits.PercentHealth);
+            itemStat.descriptions.Add("Skill Duration: ");
             itemStat.valueTypes.Add(ItemStatsDef.ValueType.Utility);
             itemStat.measurementUnits.Add(ItemStatsDef.MeasurementUnits.Seconds);
             itemStat.calculateValues = (master, stackCount) =>
             {
-                return new List<float>([.182f * stackCount, stackCount * 3]);
+                List<float> values = new();
+                values.Add(0.182f * stackCount);
+                values.Add(3 * stackCount);
+                return values;
             };
             allItemDefinitions.Add((int)RoR2Content.Items.LunarUtilityReplacement.itemIndex, itemStat);
 
+
             //Transcendence
             itemStat = new ItemStatsDef();
-            itemStat.descriptions.Add("Bonus Shields: ");
-            itemStat.valueTypes.Add(ItemStatsDef.ValueType.Healing);
+            itemStat.descriptions.Add("Health Bonus: ");
+            itemStat.valueTypes.Add(ItemStatsDef.ValueType.Health);
             itemStat.measurementUnits.Add(ItemStatsDef.MeasurementUnits.Percentage);
             itemStat.calculateValues = (master, stackCount) =>
             {
-                return new List<float>([.25f + (.25f * stackCount)]);
+                List<float> values = new();
+                values.Add(0.25f + 0.25f * stackCount);
+                return values;
             };
             allItemDefinitions.Add((int)RoR2Content.Items.ShieldOnly.itemIndex, itemStat);
 
+
             //Visions of Heresy
             itemStat = new ItemStatsDef();
-            itemStat.descriptions.Add("Charges: ");
+            itemStat.descriptions.Add("Skill Charges: ");
             itemStat.valueTypes.Add(ItemStatsDef.ValueType.Utility);
             itemStat.measurementUnits.Add(ItemStatsDef.MeasurementUnits.Number);
             itemStat.descriptions.Add("Recharge Time: ");
@@ -1460,31 +1818,41 @@ namespace LookingGlass.ItemStatsNameSpace
             itemStat.measurementUnits.Add(ItemStatsDef.MeasurementUnits.Seconds);
             itemStat.calculateValues = (master, stackCount) =>
             {
-                return new List<float>([12 * stackCount, 2 * stackCount]);
+                List<float> values = new();
+                values.Add(12 * stackCount);
+                values.Add(2 * stackCount);
+                return values;
             };
             allItemDefinitions.Add((int)RoR2Content.Items.LunarPrimaryReplacement.itemIndex, itemStat);
 
+
+            // ---------- Void Items --------------------------------------------------------------------------------
+
             //Benthic Bloom
             itemStat = new ItemStatsDef();
-            itemStat.descriptions.Add("Items Upgraded Per Stage: ");
+            itemStat.descriptions.Add("Items Upgraded: ");
             itemStat.valueTypes.Add(ItemStatsDef.ValueType.Utility);
             itemStat.measurementUnits.Add(ItemStatsDef.MeasurementUnits.Number);
             itemStat.calculateValues = (master, stackCount) =>
             {
-                return new List<float>([stackCount * 3]);
+                List<float> values = new();
+                values.Add(3 * stackCount);
+                return values;
             };
             allItemDefinitions.Add((int)DLC1Content.Items.CloverVoid.itemIndex, itemStat);
 
-            //Encrusted Key
-            itemStat = new ItemStatsDef();
-            itemStat.descriptions.Add("Charges: ");
-            itemStat.valueTypes.Add(ItemStatsDef.ValueType.Utility);
-            itemStat.measurementUnits.Add(ItemStatsDef.MeasurementUnits.Number);
-            itemStat.calculateValues = (master, stackCount) =>
-            {
-                return new List<float>([stackCount]);
-            };
-            allItemDefinitions.Add((int)DLC1Content.Items.TreasureCacheVoid.itemIndex, itemStat);
+
+            ////Encrusted Key
+            //itemStat = new ItemStatsDef();
+            //itemStat.descriptions.Add("Charges: ");
+            //itemStat.valueTypes.Add(ItemStatsDef.ValueType.Utility);
+            //itemStat.measurementUnits.Add(ItemStatsDef.MeasurementUnits.Number);
+            //itemStat.calculateValues = (master, stackCount) =>
+            //{
+            //    return new List<float>([stackCount]);
+            //};
+            //allItemDefinitions.Add((int)DLC1Content.Items.TreasureCacheVoid.itemIndex, itemStat);
+
 
             //Lost Seer's Lenses
             itemStat = new ItemStatsDef();
@@ -1493,20 +1861,26 @@ namespace LookingGlass.ItemStatsNameSpace
             itemStat.measurementUnits.Add(ItemStatsDef.MeasurementUnits.Percentage);
             itemStat.calculateValues = (master, stackCount) =>
             {
-                return new List<float>([.005f * stackCount]);
+                List<float> values = new();
+                values.Add(Utils.CalculateChanceWithNullableMaster(0.005f * stackCount, master));
+                return values;
             };
             allItemDefinitions.Add((int)DLC1Content.Items.CritGlassesVoid.itemIndex, itemStat);
 
+
             //Lysate Cell
             itemStat = new ItemStatsDef();
-            itemStat.descriptions.Add("Extra Special Skill Stacks: ");
+            itemStat.descriptions.Add("Skill Charges: ");
             itemStat.valueTypes.Add(ItemStatsDef.ValueType.Utility);
             itemStat.measurementUnits.Add(ItemStatsDef.MeasurementUnits.Number);
             itemStat.calculateValues = (master, stackCount) =>
             {
-                return new List<float>([stackCount]);
+                List<float> values = new();
+                values.Add(stackCount);
+                return values;
             };
             allItemDefinitions.Add((int)DLC1Content.Items.EquipmentMagazineVoid.itemIndex, itemStat);
+
 
             //Needletick
             itemStat = new ItemStatsDef();
@@ -1515,9 +1889,12 @@ namespace LookingGlass.ItemStatsNameSpace
             itemStat.measurementUnits.Add(ItemStatsDef.MeasurementUnits.Percentage);
             itemStat.calculateValues = (master, stackCount) =>
             {
-                return new List<float>([.1f * stackCount]);
+                List<float> values = new();
+                values.Add(Utils.CalculateChanceWithNullableMaster(0.1f * stackCount, master));
+                return values;
             };
             allItemDefinitions.Add((int)DLC1Content.Items.BleedOnHitVoid.itemIndex, itemStat);
+
 
             //Newly Hatched Zoea
             itemStat = new ItemStatsDef();
@@ -1529,9 +1906,13 @@ namespace LookingGlass.ItemStatsNameSpace
             itemStat.measurementUnits.Add(ItemStatsDef.MeasurementUnits.Seconds);
             itemStat.calculateValues = (master, stackCount) =>
             {
-                return new List<float>([stackCount, 60f / stackCount]);
+                List<float> values = new();
+                values.Add(stackCount);
+                values.Add(60f / stackCount);
+                return values; 
             };
             allItemDefinitions.Add((int)DLC1Content.Items.VoidMegaCrabItem.itemIndex, itemStat);
+
 
             //Plasma Shrimp
             itemStat = new ItemStatsDef();
@@ -1540,42 +1921,58 @@ namespace LookingGlass.ItemStatsNameSpace
             itemStat.measurementUnits.Add(ItemStatsDef.MeasurementUnits.Percentage);
             itemStat.calculateValues = (master, stackCount) =>
             {
-                return new List<float>([.4f * stackCount]);
+                List<float> values = new();
+                values.Add(0.4f * stackCount);
+                return values;
             };
             allItemDefinitions.Add((int)DLC1Content.Items.MissileVoid.itemIndex, itemStat);
 
+
             //Pluripotent Larva
             itemStat = new ItemStatsDef();
-            itemStat.descriptions.Add("Extra Lives: ");
+            itemStat.descriptions.Add("Revives: ");
             itemStat.valueTypes.Add(ItemStatsDef.ValueType.Utility);
             itemStat.measurementUnits.Add(ItemStatsDef.MeasurementUnits.Number);
             itemStat.calculateValues = (master, stackCount) =>
             {
-                return new List<float>([stackCount]);
+                List<float> values = new();
+                values.Add(stackCount);
+                return values;
             };
             allItemDefinitions.Add((int)DLC1Content.Items.ExtraLifeVoid.itemIndex, itemStat);
 
+
             //Polylute
             itemStat = new ItemStatsDef();
+            itemStat.descriptions.Add("Proc Chance: ");
+            itemStat.valueTypes.Add(ItemStatsDef.ValueType.Utility);
+            itemStat.measurementUnits.Add(ItemStatsDef.MeasurementUnits.Percentage);
             itemStat.descriptions.Add("Total Hits: ");
             itemStat.valueTypes.Add(ItemStatsDef.ValueType.Damage);
             itemStat.measurementUnits.Add(ItemStatsDef.MeasurementUnits.Number);
             itemStat.calculateValues = (master, stackCount) =>
             {
-                return new List<float>([stackCount * 3]);
+                List<float> values = new();
+                values.Add(Utils.CalculateChanceWithNullableMaster(0.25f, master));
+                values.Add(3 * stackCount);
+                return values;
             };
             allItemDefinitions.Add((int)DLC1Content.Items.ChainLightningVoid.itemIndex, itemStat);
 
+
             //Safer Spaces
             itemStat = new ItemStatsDef();
-            itemStat.descriptions.Add("Cooldown: ");
+            itemStat.descriptions.Add("Recharge Time: ");
             itemStat.valueTypes.Add(ItemStatsDef.ValueType.Utility);
             itemStat.measurementUnits.Add(ItemStatsDef.MeasurementUnits.Seconds);
             itemStat.calculateValues = (master, stackCount) =>
             {
-                return new List<float>([15 * Mathf.Pow(.9f, stackCount)]);
+                List<float> values = new();
+                values.Add(Utils.GetExponentialRechargeTime(15, 0.1f, 0.1f, stackCount));
+                return values;
             };
             allItemDefinitions.Add((int)DLC1Content.Items.BearVoid.itemIndex, itemStat);
+
 
             //Singularity Band
             itemStat = new ItemStatsDef();
@@ -1584,49 +1981,61 @@ namespace LookingGlass.ItemStatsNameSpace
             itemStat.measurementUnits.Add(ItemStatsDef.MeasurementUnits.Percentage);
             itemStat.calculateValues = (master, stackCount) =>
             {
-                return new List<float>([stackCount]);
+                List<float> values = new();
+                values.Add(stackCount);
+                return values;
             };
             allItemDefinitions.Add((int)DLC1Content.Items.ElementalRingVoid.itemIndex, itemStat);
+
 
             //Tentabauble
             itemStat = new ItemStatsDef();
             itemStat.descriptions.Add("Root Chance: ");
             itemStat.valueTypes.Add(ItemStatsDef.ValueType.Utility);
             itemStat.measurementUnits.Add(ItemStatsDef.MeasurementUnits.Percentage);
-            itemStat.descriptions.Add("Duration: ");
+            itemStat.descriptions.Add("Root Duration: ");
             itemStat.valueTypes.Add(ItemStatsDef.ValueType.Utility);
             itemStat.measurementUnits.Add(ItemStatsDef.MeasurementUnits.Seconds);
             itemStat.calculateValues = (master, stackCount) =>
             {
-                return new List<float>([1 - 1/(1 + .05f * stackCount), stackCount]);
+                List<float> values = new();
+                values.Add(Utils.CalculateChanceWithNullableMaster(0.05f * stackCount, master));
+                values.Add(stackCount);
+                return values;
             };
             allItemDefinitions.Add((int)DLC1Content.Items.SlowOnHitVoid.itemIndex, itemStat);
+
 
             //Voidsent Flame
             itemStat = new ItemStatsDef();
             itemStat.descriptions.Add("Radius: ");
             itemStat.valueTypes.Add(ItemStatsDef.ValueType.Damage);
             itemStat.measurementUnits.Add(ItemStatsDef.MeasurementUnits.Meters);
-            itemStat.descriptions.Add("Base Damage: ");
+            itemStat.descriptions.Add("Pillar Damage: ");
             itemStat.valueTypes.Add(ItemStatsDef.ValueType.Damage);
             itemStat.measurementUnits.Add(ItemStatsDef.MeasurementUnits.Percentage);
             itemStat.calculateValues = (master, stackCount) =>
             {
-                return new List<float>([9.6f + (2.4f * stackCount), 1.04f + (1.56f * stackCount)]);
+                List<float> values = new();
+                values.Add(9.6f + (2.4f * stackCount));
+                values.Add(1.04f + (1.56f * stackCount));
+                return values;
             };
             allItemDefinitions.Add((int)DLC1Content.Items.ExplodeOnDeathVoid.itemIndex, itemStat);
+
 
             //Weeping Fungus
             itemStat = new ItemStatsDef();
             itemStat.descriptions.Add("Sprint Healing: ");
             itemStat.valueTypes.Add(ItemStatsDef.ValueType.Healing);
-            itemStat.measurementUnits.Add(ItemStatsDef.MeasurementUnits.Percentage);
+            itemStat.measurementUnits.Add(ItemStatsDef.MeasurementUnits.PercentHealth);
             itemStat.calculateValues = (master, stackCount) =>
             {
-                return new List<float>([.02f * stackCount]);
+                List<float> values = new();
+                values.Add(0.02f * stackCount);
+                return values;
             };
             allItemDefinitions.Add((int)DLC1Content.Items.MushroomVoid.itemIndex, itemStat);
-
         }
     }
 }

--- a/LookingGlass/ItemStats/ItemStats.cs
+++ b/LookingGlass/ItemStats/ItemStats.cs
@@ -173,6 +173,7 @@ namespace LookingGlass.ItemStatsNameSpace
                                 case ItemStatsDef.ValueType.Void:
                                     itemDescription += "<style=\"cIsVoid";
                                     break;
+                                case ItemStatsDef.ValueType.Gold:
                                 case ItemStatsDef.ValueType.HumanObjective:
                                     itemDescription += "<style=\"cHumanObjective";
                                     break;
@@ -203,6 +204,7 @@ namespace LookingGlass.ItemStatsNameSpace
                                 case ItemStatsDef.ValueType.Shrine:
                                     itemDescription += "<style=\"cShrine";
                                     break;
+                                case ItemStatsDef.ValueType.Armor:
                                 case ItemStatsDef.ValueType.Event:
                                     itemDescription += "<style=\"cEvent";
                                     break;
@@ -218,11 +220,17 @@ namespace LookingGlass.ItemStatsNameSpace
                                 case ItemStatsDef.MeasurementUnits.Percentage:
                                     itemDescription += $"\">{values[i] * 100:0.###}%</style>";
                                     break;
-                                case ItemStatsDef.MeasurementUnits.Health:
+                                case ItemStatsDef.MeasurementUnits.FlatHealth:
                                     itemDescription += $"\">{values[i]:0.###} HP</style>";
                                     break;
-                                case ItemStatsDef.MeasurementUnits.Healing:
+                                case ItemStatsDef.MeasurementUnits.PercentHealth:
+                                    itemDescription += $"\">{values[i] * 100:0.###}% HP</style>";
+                                    break;
+                                case ItemStatsDef.MeasurementUnits.FlatHealing:
                                     itemDescription += $"\">{values[i]:0.###} HP/s</style>";
+                                    break;
+                                case ItemStatsDef.MeasurementUnits.PercentHealing:
+                                    itemDescription += $"\">{values[i] * 100:0.###}% HP/s</style>";
                                     break;
                                 case ItemStatsDef.MeasurementUnits.Number:
                                     itemDescription += $"\">{values[i]:0.###}</style>";

--- a/LookingGlass/ItemStats/ItemStatsDef.cs
+++ b/LookingGlass/ItemStats/ItemStatsDef.cs
@@ -14,6 +14,7 @@ namespace LookingGlass.ItemStatsNameSpace
             Utility,
             Health,
             Void,
+            Gold,
             HumanObjective,
             LunarObjective,
             Stack,
@@ -24,14 +25,17 @@ namespace LookingGlass.ItemStatsNameSpace
             Sub,
             Mono,
             Shrine,
+            Armor,
             Event
         }
         public enum MeasurementUnits
         {
             Meters,
             Percentage,
-            Health,
-            Healing,
+            FlatHealth,
+            PercentHealth,
+            FlatHealing,
+            PercentHealing,
             Number,
             Seconds
         }

--- a/LookingGlass/ItemStats/ItemStatsDef.cs
+++ b/LookingGlass/ItemStats/ItemStatsDef.cs
@@ -14,7 +14,6 @@ namespace LookingGlass.ItemStatsNameSpace
             Utility,
             Health,
             Void,
-            Gold,
             HumanObjective,
             LunarObjective,
             Stack,
@@ -25,19 +24,20 @@ namespace LookingGlass.ItemStatsNameSpace
             Sub,
             Mono,
             Shrine,
-            Armor,
-            Event
+            Event,
+            Gold,
+            Armor
         }
         public enum MeasurementUnits
         {
             Meters,
             Percentage,
             FlatHealth,
-            PercentHealth,
             FlatHealing,
-            PercentHealing,
             Number,
-            Seconds
+            Seconds,
+            PercentHealth,
+            PercentHealing
         }
         public List<string> descriptions = new List<string>();
         public List<ValueType> valueTypes = new List<ValueType>();

--- a/LookingGlass/StatsDisplay/StatsDisplayDefinitions.cs
+++ b/LookingGlass/StatsDisplay/StatsDisplayDefinitions.cs
@@ -104,12 +104,12 @@ namespace LookingGlass.StatsDisplay
 
             StatsDisplayClass.statDictionary.Add("critWithLuck", cachedUserBody =>
             {
-                float critWithLuck = Utils.CalculateChanceWithLuck(cachedUserBody.crit, Utils.GetLuckFromCachedUserBody(cachedUserBody)) * 100f;
+                float critWithLuck = Utils.CalculateChanceWithLuck(cachedUserBody.crit / 100f, Utils.GetLuckFromCachedUserBody(cachedUserBody)) * 100f;
                 return $"{damageString}{critWithLuck.ToString(floatPrecision)}%{styleString}";
             });
             StatsDisplayClass.statDictionary.Add("bleedChanceWithLuck", cachedUserBody =>
             {
-                float bleedChanceWithLuck = Utils.CalculateChanceWithLuck(cachedUserBody.bleedChance, Utils.GetLuckFromCachedUserBody(cachedUserBody)) * 100f;
+                float bleedChanceWithLuck = Utils.CalculateChanceWithLuck(cachedUserBody.bleedChance / 100f, Utils.GetLuckFromCachedUserBody(cachedUserBody)) * 100f;
                 return $"{damageString}{bleedChanceWithLuck.ToString(floatPrecision)}%{styleString}";
             });
 
@@ -136,7 +136,7 @@ namespace LookingGlass.StatsDisplay
             });
             StatsDisplayClass.statDictionary.Add("instaKillChance", cachedUserBody => {
                 int stackCount = cachedUserBody.inventory.GetItemCount(DLC1Content.Items.CritGlassesVoid);
-                float instakillChance = Utils.CalculateChanceWithLuck(.5f * stackCount, Utils.GetLuckFromCachedUserBody(cachedUserBody)) * 100f;
+                float instakillChance = Utils.CalculateChanceWithLuck(.005f * stackCount, Utils.GetLuckFromCachedUserBody(cachedUserBody)) * 100f;
                 return $"{damageString}{instakillChance.ToString(floatPrecision)}%{styleString}";
             });
             StatsDisplayClass.statDictionary.Add("difficultyCoefficient", cachedUserBody => { return $"{utilityString}{Run.instance.difficultyCoefficient}{styleString}"; });

--- a/LookingGlass/StatsDisplay/StatsDisplayDefinitions.cs
+++ b/LookingGlass/StatsDisplay/StatsDisplayDefinitions.cs
@@ -104,12 +104,12 @@ namespace LookingGlass.StatsDisplay
 
             StatsDisplayClass.statDictionary.Add("critWithLuck", cachedUserBody =>
             {
-                float critWithLuck = Utils.CalculateChance(cachedUserBody.crit, Utils.GetLuckFromCachedUserBody(cachedUserBody)) * 100f;
+                float critWithLuck = Utils.CalculateChanceWithLuck(cachedUserBody.crit, Utils.GetLuckFromCachedUserBody(cachedUserBody)) * 100f;
                 return $"{damageString}{critWithLuck.ToString(floatPrecision)}%{styleString}";
             });
             StatsDisplayClass.statDictionary.Add("bleedChanceWithLuck", cachedUserBody =>
             {
-                float bleedChanceWithLuck = Utils.CalculateChance(cachedUserBody.bleedChance, Utils.GetLuckFromCachedUserBody(cachedUserBody)) * 100f;
+                float bleedChanceWithLuck = Utils.CalculateChanceWithLuck(cachedUserBody.bleedChance, Utils.GetLuckFromCachedUserBody(cachedUserBody)) * 100f;
                 return $"{damageString}{bleedChanceWithLuck.ToString(floatPrecision)}%{styleString}";
             });
 
@@ -136,7 +136,7 @@ namespace LookingGlass.StatsDisplay
             });
             StatsDisplayClass.statDictionary.Add("instaKillChance", cachedUserBody => {
                 int stackCount = cachedUserBody.inventory.GetItemCount(DLC1Content.Items.CritGlassesVoid);
-                float instakillChance = Utils.CalculateChance(.5f * stackCount, Utils.GetLuckFromCachedUserBody(cachedUserBody)) * 100f;
+                float instakillChance = Utils.CalculateChanceWithLuck(.5f * stackCount, Utils.GetLuckFromCachedUserBody(cachedUserBody)) * 100f;
                 return $"{damageString}{instakillChance.ToString(floatPrecision)}%{styleString}";
             });
             StatsDisplayClass.statDictionary.Add("difficultyCoefficient", cachedUserBody => { return $"{utilityString}{Run.instance.difficultyCoefficient}{styleString}"; });

--- a/LookingGlass/StatsDisplay/StatsDisplayDefinitions.cs
+++ b/LookingGlass/StatsDisplay/StatsDisplayDefinitions.cs
@@ -24,11 +24,7 @@ namespace LookingGlass.StatsDisplay
             floatPrecision = "0." + new string('#', StatsDisplayClass.floatPrecision.Value);
             StatsDisplayClass.statDictionary.Clear();
             StatsDisplayClass.statDictionary.Add("luck", cachedUserBody => {
-                if (cachedUserBody.master)
-                {
-                    return $"{utilityString}{(cachedUserBody.master.luck).ToString(floatPrecision)}{styleString}";
-                }
-                return $"{utilityString}{(cachedUserBody.inventory.GetItemCount(RoR2Content.Items.Clover) - cachedUserBody.inventory.GetItemCount(RoR2Content.Items.LunarBadLuck))}{styleString}";
+                return $"{utilityString}{Utils.GetLuckFromCachedUserBody(cachedUserBody).ToString(floatPrecision)}{styleString}";
             });
             StatsDisplayClass.statDictionary.Add("baseDamage", cachedUserBody => { return $"{damageString}{(cachedUserBody.damage).ToString(floatPrecision)}{styleString}"; });
             StatsDisplayClass.statDictionary.Add("crit", cachedUserBody => { return $"{damageString}{(cachedUserBody.crit).ToString(floatPrecision)}%{styleString}"; });
@@ -108,13 +104,13 @@ namespace LookingGlass.StatsDisplay
 
             StatsDisplayClass.statDictionary.Add("critWithLuck", cachedUserBody =>
             {
-                int luck = cachedUserBody.inventory.GetItemCount(RoR2Content.Items.Clover) - cachedUserBody.inventory.GetItemCount(RoR2Content.Items.LunarBadLuck);
-                return $"{damageString}{CalculateChance(cachedUserBody.crit, luck).ToString(floatPrecision)}%{styleString}";
+                float critWithLuck = Utils.CalculateChance(cachedUserBody.crit, Utils.GetLuckFromCachedUserBody(cachedUserBody)) * 100f;
+                return $"{damageString}{critWithLuck.ToString(floatPrecision)}%{styleString}";
             });
             StatsDisplayClass.statDictionary.Add("bleedChanceWithLuck", cachedUserBody =>
             {
-                int luck = cachedUserBody.inventory.GetItemCount(RoR2Content.Items.Clover) - cachedUserBody.inventory.GetItemCount(RoR2Content.Items.LunarBadLuck);
-                return $"{damageString}{CalculateChance(cachedUserBody.bleedChance, luck).ToString(floatPrecision)}%{styleString}";
+                float bleedChanceWithLuck = Utils.CalculateChance(cachedUserBody.bleedChance, Utils.GetLuckFromCachedUserBody(cachedUserBody)) * 100f;
+                return $"{damageString}{bleedChanceWithLuck.ToString(floatPrecision)}%{styleString}";
             });
 
             StatsDisplayClass.statDictionary.Add("velocity", cachedUserBody =>
@@ -128,7 +124,7 @@ namespace LookingGlass.StatsDisplay
             });
             StatsDisplayClass.statDictionary.Add("teddyBearBlockChance", cachedUserBody => {
                 int stackCount = cachedUserBody.inventory.GetItemCount(RoR2Content.Items.Bear);
-                return $"{utilityString}{(((0.15f * stackCount) / ((0.15f * stackCount) + 1)) * 100).ToString(floatPrecision)}%{styleString}";
+                return $"{utilityString}{(((0.15f * stackCount) / ((0.15f * stackCount) + 1)) * 100f).ToString(floatPrecision)}%{styleString}";
             });
             StatsDisplayClass.statDictionary.Add("saferSpacesCD", cachedUserBody => {
                 int stackCount = cachedUserBody.inventory.GetItemCount(DLC1Content.Items.BearVoid);
@@ -139,33 +135,12 @@ namespace LookingGlass.StatsDisplay
                 return $"{utilityString}{(15 * Mathf.Pow(.9f, stackCount)).ToString(floatPrecision)}{styleString}";
             });
             StatsDisplayClass.statDictionary.Add("instaKillChance", cachedUserBody => {
-                int luck = cachedUserBody.inventory.GetItemCount(RoR2Content.Items.Clover) - cachedUserBody.inventory.GetItemCount(RoR2Content.Items.LunarBadLuck);
                 int stackCount = cachedUserBody.inventory.GetItemCount(DLC1Content.Items.CritGlassesVoid);
-                return $"{damageString}{(CalculateChance(.5f * stackCount, luck)).ToString(floatPrecision)}%{styleString}";
+                float instakillChance = Utils.CalculateChance(.5f * stackCount, Utils.GetLuckFromCachedUserBody(cachedUserBody)) * 100f;
+                return $"{damageString}{instakillChance.ToString(floatPrecision)}%{styleString}";
             });
             StatsDisplayClass.statDictionary.Add("difficultyCoefficient", cachedUserBody => { return $"{utilityString}{Run.instance.difficultyCoefficient}{styleString}"; });
 
-        }
-        internal static float CalculateChance(float baseChance, int luck) //baseChance should be between 0 and 1
-        {
-            float num;
-            if (baseChance >= 100)
-            {
-                return 100;
-            }
-            else if (luck > 0)
-            {
-                num = (1 - Mathf.Pow(1 - (baseChance * .01f), luck + 1)) * 100;
-            }
-            else if (luck < 0)
-            {
-                num = Mathf.Pow((baseChance * .01f), Mathf.Abs(luck) + 1) * 100;
-            }
-            else
-            {
-                num = baseChance;
-            }
-            return num;
         }
     }
 }

--- a/LookingGlass/Utils.cs
+++ b/LookingGlass/Utils.cs
@@ -1,0 +1,28 @@
+﻿using RoR2;
+using System;
+using UnityEngine;
+
+namespace LookingGlass
+{
+    class Utils
+    {
+        public static float CalculateChance(float baseChance, float luckIn)
+        {
+            int luck = Mathf.CeilToInt(luckIn);
+            if (luck > 0)
+                return 1f - Mathf.Pow(1f - baseChance, luck + 1);
+            if (luck < 0)
+                return Mathf.Pow(baseChance, Mathf.Abs(luck) + 1);
+
+            return baseChance;
+        }
+
+        public static float GetLuckFromCachedUserBody(CharacterBody cachedUserBody)
+        {
+            // Check for modded luck values
+            if (cachedUserBody && cachedUserBody.master) return cachedUserBody.master.luck;
+
+            return cachedUserBody.inventory.GetItemCount(RoR2Content.Items.Clover) - cachedUserBody.inventory.GetItemCount(RoR2Content.Items.LunarBadLuck);
+        }
+    }
+}

--- a/LookingGlass/Utils.cs
+++ b/LookingGlass/Utils.cs
@@ -6,7 +6,15 @@ namespace LookingGlass
 {
     class Utils
     {
-        public static float CalculateChance(float baseChance, float luckIn)
+        public static float CalculateChanceWithNullableMaster(float baseChance, CharacterMaster master)
+        {
+            if (master)
+                return CalculateChanceWithLuck(baseChance, master.luck);
+            
+            return baseChance;
+        }
+
+        public static float CalculateChanceWithLuck(float baseChance, float luckIn)
         {
             int luck = Mathf.CeilToInt(luckIn);
             if (luck > 0)
@@ -23,6 +31,26 @@ namespace LookingGlass
             if (cachedUserBody && cachedUserBody.master) return cachedUserBody.master.luck;
 
             return cachedUserBody.inventory.GetItemCount(RoR2Content.Items.Clover) - cachedUserBody.inventory.GetItemCount(RoR2Content.Items.LunarBadLuck);
+        }
+
+        public static float GetExponentialRechargeTime(float baseCooldown, float basePercent, float extraPercent, int count)
+        {
+            return baseCooldown * basePercent * Mathf.Pow(1 - extraPercent, count - 1);
+        }
+
+        public static float GetExponentialStacking(float basePercent, float extraPercent, int count)
+        {
+            return 1 - (1 - basePercent) * Mathf.Pow(1 - extraPercent, count - 1);
+        }
+
+        public static float GetHyperbolicStacking(float basePercent, float extraPercent, int count)
+        {
+            return 1f - 1f / (1f + basePercent + extraPercent * (count - 1));
+        }
+
+        public static float GetBandolierStacking(int count)
+        {
+            return 1f - 1f / Mathf.Pow(1f + count, 0.33f);
         }
     }
 }


### PR DESCRIPTION
Looks like a big update but I did the following:
 - fixed luck display calculation for critWithLuck, bleedChanceWithLuck, and instakillChance
 - updated item stats to use luck whenever possible for chance effects that are affected by luck
 - added a few more useful MeasurementUnits and ValueTypes