### PR TITLE
Fixes to Command menu hooks

### DIFF
--- a/LookingGlass/CommandItemCount/CommandItemCount.cs
+++ b/LookingGlass/CommandItemCount/CommandItemCount.cs
@@ -48,6 +48,8 @@ namespace LookingGlass.CommandItemCount
             {
                 return;
             }
+            string parentName = self.gameObject.name;
+            bool withOneMore = parentName.StartsWith("OptionPickerPanel") || parentName.StartsWith("CommandPickerPanel");
             ReadOnlyCollection<MPButton> elements = self.buttonAllocator.elements;
             Inventory inventory = LocalUserManager.GetFirstLocalUser().cachedMasterController.master.inventory;
             for (int i = 0; i < options.Length; i++)
@@ -57,7 +59,7 @@ namespace LookingGlass.CommandItemCount
                 if (commandItemCount.Value)
                     CreateNumber(elements[i].transform, count);
                 if (commandToolTips.Value)
-                    CreateToolTip(elements[i].transform, PickupCatalog.GetPickupDef(options[i].pickupIndex), count);
+                    CreateToolTip(elements[i].transform, PickupCatalog.GetPickupDef(options[i].pickupIndex), count, withOneMore);
             }
         }
         void CreateNumber(Transform parent, int count)
@@ -83,7 +85,7 @@ namespace LookingGlass.CommandItemCount
             rectTransform.sizeDelta = Vector2.zero;
             rectTransform.anchoredPosition = new Vector2(-5f, -1.5f);
         }
-        void CreateToolTip(Transform parent, PickupDef pickupDefinition, int count)
+        void CreateToolTip(Transform parent, PickupDef pickupDefinition, int count, bool withOneMore)
         {
             ItemDef itemDefinition = ItemCatalog.GetItemDef(pickupDefinition.itemIndex);
             EquipmentDef equipmentDef = EquipmentCatalog.GetEquipmentDef(pickupDefinition.equipmentIndex);
@@ -97,7 +99,7 @@ namespace LookingGlass.CommandItemCount
 
             if (isItem && ItemStats.itemStats.Value)
             {
-                string stats = ItemStats.GetDescription(itemDefinition, itemDefinition.itemIndex, count, null, true);
+                string stats = ItemStats.GetDescription(itemDefinition, itemDefinition.itemIndex, count, null, withOneMore);
 
                 if (stats != null)
                 {

--- a/LookingGlass/ItemStats/ItemStats.cs
+++ b/LookingGlass/ItemStats/ItemStats.cs
@@ -143,7 +143,7 @@ namespace LookingGlass.ItemStatsNameSpace
                     ItemStatsDef itemStats = ItemDefinitions.allItemDefinitions[(int)newItemIndex];
                     if (withOneMore && itemStats.descriptions.Count != 0)
                     {
-                        itemDescription += $"\nWith one more stack than you have:";
+                        itemDescription += $"\nWith one more stack, you will have:";
                         newItemCount++;
                     }
                     if (master == null)


### PR DESCRIPTION
This makes a couple minor fixes to the Command menu hooks, both related to the "With one more stack" feature:

- Restricts it to only show up on CommandPickerPanel and OptionPickerPanel. This excludes scrappers and the eggs from the Devotion artifact, since in those cases you're giving _away_ items rather than gaining items.
  - I made it specifically show up on _only_ those two panels, rather than excluding it from ScrapperPickerPanel and LemurianEggPickerPanel. This means it could potentially exclude panels added by mods, but IMO it's probably less confusing to default to not showing the message, rather than default to showing it.
- Improves grammar of the message (`With one more stack than you have` -> `With one more stack, you will have`)