### PR TITLE
Add .editorconfig to make the publicizer warnings quieter

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,4 @@
+﻿[*.cs]
+
+# Publicizer001: Accessing a member that was not originally public
+dotnet_diagnostic.Publicizer001.severity = suggestion

--- a/LookingGlass.sln
+++ b/LookingGlass.sln
@@ -5,6 +5,11 @@ VisualStudioVersion = 17.5.33530.505
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "LookingGlass", "LookingGlass\LookingGlass.csproj", "{1AE65614-D7D8-453A-9890-E63B6D77192F}"
 EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{6DD41A89-18CA-47B7-AAD6-A253E3C40DC9}"
+	ProjectSection(SolutionItems) = preProject
+		.editorconfig = .editorconfig
+	EndProjectSection
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU

--- a/LookingGlass/LookingGlass.csproj
+++ b/LookingGlass/LookingGlass.csproj
@@ -8,6 +8,10 @@
     <Product>LookingGlass</Product>
     <BepInExPluginGuid>droppod.lookingglass</BepInExPluginGuid>
   </PropertyGroup>
+
+  <ItemGroup>
+    <None Include="..\.editorconfig" Link=".editorconfig" />
+  </ItemGroup>
   
   <ItemGroup>
     <PackageReference Include="BepInEx.Analyzers" Version="1.0.*">


### PR DESCRIPTION
This changes the severity of Publicizer001 (warning about using private members) to be a suggestion rather than a full-blown warning. I agree it's not a bad idea to mark usages of private members, hence why I opted not to hide it entirely, but it also _really_ does not need to be spamming the output on every build.