### PR TITLE
Added Proc Coefficient data to ability description

### DIFF
--- a/LookingGlass/ItemStats/ItemStats.cs
+++ b/LookingGlass/ItemStats/ItemStats.cs
@@ -12,6 +12,7 @@ using System.Text;
 using static RoR2.Chat;
 using System.Linq;
 using LookingGlass.StatsDisplay;
+using RoR2.Skills;
 
 namespace LookingGlass.ItemStatsNameSpace
 {
@@ -26,6 +27,7 @@ namespace LookingGlass.ItemStatsNameSpace
         private static Hook overrideHook;
         private static Hook overrideHook2;
         private static Hook overrideHook3;
+        private static Hook overrideHook4;
         public ItemStats()
         {
             Setup();
@@ -69,6 +71,10 @@ namespace LookingGlass.ItemStatsNameSpace
             targetMethod = typeof(PingerController).GetMethod(nameof(PingerController.SetCurrentPing), System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance);
             destMethod = typeof(ItemStats).GetMethod(nameof(ItemPinged), System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance);
             overrideHook3 = new Hook(targetMethod, destMethod, this);
+
+            targetMethod = typeof(RoR2.UI.SkillIcon).GetMethod(nameof(RoR2.UI.SkillIcon.Update), System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance);
+            destMethod = typeof(ItemStats).GetMethod(nameof(SkillUpdate), System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance);
+            overrideHook4 = new Hook(targetMethod, destMethod, this);
         }
 
         internal void EquipText(EquipmentIcon self)
@@ -115,6 +121,16 @@ namespace LookingGlass.ItemStatsNameSpace
             {
                 SetDescription(self, newItemIndex, newItemCount);
             }
+        }
+        void SkillUpdate(Action<SkillIcon> orig, SkillIcon self)
+        {
+            orig(self);
+            // TODO Change skills description to include proc cof data
+            string desc = Language.GetString(self.targetSkill.skillDescriptionToken);
+
+            if (ProcCoefficientData.hasProcCoefficient(self.targetSkill.skillNameToken)) desc = desc + "\nProc Coefficient: <color=#a6b3bd>" + ProcCoefficientData.GetProcCoefficient(self.targetSkill.skillNameToken) + "</color>\n";
+
+            self.tooltipProvider.overrideBodyText = desc;
         }
         internal static void SetDescription(ItemIcon self, ItemIndex newItemIndex, int newItemCount)
         {

--- a/LookingGlass/ItemStats/ProcCoefficientData.cs
+++ b/LookingGlass/ItemStats/ProcCoefficientData.cs
@@ -1,0 +1,128 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace LookingGlass.ItemStatsNameSpace
+{
+    internal class ProcCoefficientData
+    {
+        private static readonly Dictionary<string, float> skills = new Dictionary<string, float>();
+
+        public static float GetProcCoefficient(string name)
+        {
+            return skills.TryGetValue(name, out var value) ? value : 1f;
+        }
+
+        public static bool hasProcCoefficient(string name)
+        {
+            return skills.ContainsKey(name);
+        }
+
+        static ProcCoefficientData()
+        {
+            // Acrid
+            skills.Add("CROCO_PRIMARY_NAME", 1f);
+            skills.Add("CROCO_SECONDARY_NAME", 1f);
+            skills.Add("CROCO_SECONDARY_ALT_NAME", 1f);
+            skills.Add("CROCO_UTILITY_NAME", 1f); // Leap: 1.0 Pool: 0.1
+            skills.Add("CROCO_UTILITY_ALT1_NAME", 1f);
+            skills.Add("CROCO_SPECIAL_NAME", 1f);
+
+            // Artificer
+            skills.Add("MAGE_PRIMARY_FIRE_NAME", 1f);
+            skills.Add("MAGE_PRIMARY_LIGHTNING_NAME", 1f);
+            skills.Add("MAGE_SECONDARY_ICE_NAME", 1f);
+            skills.Add("MAGE_SECONDARY_LIGHTNING_NAME", 1f);
+            skills.Add("MAGE_UTILITY_ICE_NAME", 1f);
+            skills.Add("MAGE_SPECIAL_FIRE_NAME", 1f);
+            skills.Add("MAGE_SPECIAL_LIGHTNING_NAME", 1f);
+
+            // Bandit
+            skills.Add("BANDIT2_PRIMARY_NAME", 0.5f);
+            skills.Add("BANDIT2_SECONDARY_NAME", 1f);
+            skills.Add("BANDIT2_PRIMARY_ALT_NAME", 1f);
+            skills.Add("BANDIT2_SECONDARY_ALT_NAME", 1f);
+            skills.Add("BANDIT2_UTILITY_NAME", 1f);
+            skills.Add("BANDIT2_SPECIAL_NAME", 1f);
+            skills.Add("BANDIT2_SPECIAL_ALT_NAME", 1f);
+
+            // Capitan
+            skills.Add("CAPTAIN_PRIMARY_NAME", 0.75f);
+            skills.Add("CAPTAIN_SECONDARY_NAME", 1f);
+            skills.Add("CAPTAIN_UTILITY_NAME", 1f);
+            skills.Add("CAPTAIN_UTILITY_ALT1_NAME", 1f);
+
+            // Commando
+            skills.Add("COMMANDO_PRIMARY_NAME", 1f);
+            skills.Add("COMMANDO_SECONDARY_NAME", 1f);
+            skills.Add("COMMANDO_SECONDARY_ALT1_NAME", 0.5f);
+            skills.Add("COMMANDO_SPECIAL_NAME", 1f);
+            skills.Add("COMMANDO_SPECIAL_ALT1_NAME", 1f);
+
+            // Engineer
+            skills.Add("ENGI_PRIMARY_NAME", 1f);
+            skills.Add("ENGI_SECONDARY_NAME", 1f);
+            skills.Add("ENGI_SPIDERMINE_NAME", 1f);
+            skills.Add("ENGI_SKILL_HARPOON_NAME", 1f);
+            skills.Add("ENGI_SPECIAL_NAME", 1f);
+            skills.Add("ENGI_SPECIAL_ALT1_NAME", 0.6f);
+
+            // Huntress
+            skills.Add("HUNTRESS_PRIMARY_NAME", 1f);
+            skills.Add("HUNTRESS_PRIMARY_ALT_NAME", 0.7f);
+            skills.Add("HUNTRESS_SECONDARY_NAME", 0.8f);
+            skills.Add("HUNTRESS_SPECIAL_NAME", 0.2f);
+            skills.Add("HUNTRESS_SPECIAL_ALT1_NAME", 1f);
+
+            // Loader <3
+            skills.Add("LOADER_PRIMARY_NAME", 1f);
+            skills.Add("LOADER_YANKHOOK_NAME", 1f);
+            skills.Add("LOADER_UTILITY_NAME", 1f);
+            skills.Add("LOADER_UTILITY_ALT1_NAME", 1f);
+            skills.Add("LOADER_SPECIAL_NAME", 0.5f);
+            skills.Add("LOADER_SPECIAL_ALT_NAME", 1f);
+
+            // Mercenary
+            skills.Add("MERC_PRIMARY_NAME", 1f);
+            skills.Add("MERC_SECONDARY_NAME", 1f);
+            skills.Add("MERC_SECONDARY_ALT1_NAME", 1f);
+            skills.Add("MERC_UTILITY_NAME", 1f);
+            skills.Add("MERC_UTILITY_ALT1_NAME", 1f);
+            skills.Add("MERC_SPECIAL_NAME", 1f);
+            skills.Add("MERC_SPECIAL_ALT1_NAME", 1f);
+
+            // MUL-T
+            skills.Add("TOOLBOT_PRIMARY_NAME", 0.6f);
+            skills.Add("TOOLBOT_PRIMARY_ALT1_NAME", 1f);
+            skills.Add("TOOLBOT_PRIMARY_ALT2_NAME", 1.5f);
+            skills.Add("TOOLBOT_PRIMARY_ALT3_NAME", 1f);
+            skills.Add("TOOLBOT_SECONDARY_NAME", 1f);
+            skills.Add("TOOLBOT_UTILITY_NAME", 1f);
+
+            // REX
+            skills.Add("TREEBOT_PRIMARY_NAME", 0.5f);
+            skills.Add("TREEBOT_SECONDARY_NAME", 1f);
+            skills.Add("TREEBOT_SECONDARY_ALT1_NAME", 0.5f);
+            skills.Add("TREEBOT_UTILITY_NAME", 0f);
+            skills.Add("TREEBOT_UTILITY_ALT1_NAME", 0.5f);
+            skills.Add("TREEBOT_SPECIAL_NAME", 1f);
+            skills.Add("TREEBOT_SPECIAL_ALT1_NAME", 1f);
+
+            // Railgunner
+            skills.Add("RAILGUNNER_PRIMARY_NAME", 1f);
+            skills.Add("RAILGUNNER_SECONDARY_NAME", 1f);
+            skills.Add("RAILGUNNER_SECONDARY_ALT_NAME", 1f);
+            skills.Add("RAILGUNNER_UTILITY_NAME", 0f);
+            skills.Add("RAILGUNNER_UTILITY_ALT_NAME", 0f);
+            skills.Add("RAILGUNNER_SPECIAL_NAME", 3f);
+            skills.Add("RAILGUNNER_SPECIAL_ALT_NAME", 1.5f);
+
+            // Void Fiend
+            // TODO differentiate between corrupted and normal
+            skills.Add("VOIDSURVIVOR_PRIMARY_NAME", 1f);
+            skills.Add("VOIDSURVIVOR_SECONDARY_NAME", 1f);
+
+
+        }
+    }
+}


### PR DESCRIPTION
Aimed to address issue #62.
Adds only the Proc Coefficient data when hovering over ability during the game.
Does not work for Void Fiend's corrupted skills (Corrupted Drown)