### PR TITLE
More options for item sorting

### DIFF
--- a/LookingGlass/AutoSortItems/AutoSortItemsClass.cs
+++ b/LookingGlass/AutoSortItems/AutoSortItemsClass.cs
@@ -303,7 +303,7 @@ namespace LookingGlass.AutoSortItems
                             itemTierLists.Add(new List<ItemIndex>());
                         }
                     }
-                    Log.Debug(Utils.DictToString(tierMatcher));
+                    Log.Debug($"tierMatcher: {Utils.DictToString(tierMatcher)}");
                 }
                 self.itemOrder = SortItems(self.itemOrder, self.itemOrderCount, self, ScrapSorting.Value != ScrapSortMode.Mixed, SortByTier.Value, SortByStackSize.Value, DescendingStackSize.Value);
             }

--- a/LookingGlass/AutoSortItems/AutoSortItemsClass.cs
+++ b/LookingGlass/AutoSortItems/AutoSortItemsClass.cs
@@ -96,7 +96,7 @@ namespace LookingGlass.AutoSortItems
             ModSettingsManager.AddOption(new CheckBoxOption(SeperateScrap, new CheckBoxConfig() { restartRequired = false }));
             ModSettingsManager.AddOption(new CheckBoxOption(SortByTier, new CheckBoxConfig() { restartRequired = false }));
             ModSettingsManager.AddOption(new StringInputFieldOption(TierOrder, new InputFieldConfig() { restartRequired = false, checkIfDisabled = CheckTierSort, lineType = TMPro.TMP_InputField.LineType.MultiLineSubmit, submitOn = InputFieldConfig.SubmitEnum.OnExitOrSubmit}));
-            ModSettingsManager.AddOption(new CheckBoxOption(CombineVoidTiers, new CheckBoxConfig() { restartRequired = false }));
+            ModSettingsManager.AddOption(new CheckBoxOption(CombineVoidTiers, new CheckBoxConfig() { restartRequired = false, checkIfDisabled = CheckTierSort }));
             ModSettingsManager.AddOption(new CheckBoxOption(DescendingTier, new CheckBoxConfig() { restartRequired = false, checkIfDisabled = CheckTierSort }));
             ModSettingsManager.AddOption(new CheckBoxOption(SortByStackSize, new CheckBoxConfig() { restartRequired = false }));
             ModSettingsManager.AddOption(new CheckBoxOption(DescendingStackSize, new CheckBoxConfig() { restartRequired = false, checkIfDisabled = CheckStackSort }));
@@ -261,7 +261,7 @@ namespace LookingGlass.AutoSortItems
                     itemTierLists.Clear();
                     foreach (string tierString in TierOrder.Value.Split(' '))
                     {
-                        if (Enum.TryParse(tierString, out ItemTier tier))
+                        if (Enum.TryParse(tierString, out ItemTier tier) && !tierMatcher.ContainsKey(tier))
                         {
                             tierMatcher.Add(tier, itemTierLists.Count);
                             itemTierLists.Add(new List<ItemIndex>());
@@ -273,12 +273,13 @@ namespace LookingGlass.AutoSortItems
                         {
                             noTierNum = itemTierLists.Count;
                         }
-                        if (!tierMatcher.ContainsKey(tierDef.tier)) // use default ordering for any not present in the setting (TODO: test this probably?)
+                        if (!tierMatcher.ContainsKey(tierDef.tier)) // use default ordering for any not present in the setting
                         {
                             tierMatcher.Add(tierDef.tier, itemTierLists.Count);
                             itemTierLists.Add(new List<ItemIndex>());
                         }
                     }
+                    Log.Debug(Utils.DictToString(tierMatcher));
                 }
                 self.itemOrder = SortItems(self.itemOrder, self.itemOrderCount, self, SeperateScrap.Value, SortByTier.Value, DescendingTier.Value, SortByStackSize.Value, DescendingStackSize.Value);
             }

--- a/LookingGlass/AutoSortItems/AutoSortItemsClass.cs
+++ b/LookingGlass/AutoSortItems/AutoSortItemsClass.cs
@@ -1,6 +1,7 @@
 ﻿using BepInEx.Configuration;
 using LookingGlass.Base;
 using MonoMod.RuntimeDetour;
+using RiskOfOptions.Components.Options;
 using RiskOfOptions.OptionConfigs;
 using RiskOfOptions.Options;
 using RiskOfOptions;
@@ -96,6 +97,8 @@ namespace LookingGlass.AutoSortItems
             ModSettingsManager.AddOption(new CheckBoxOption(SeperateScrap, new CheckBoxConfig() { restartRequired = false }));
             ModSettingsManager.AddOption(new CheckBoxOption(SortByTier, new CheckBoxConfig() { restartRequired = false }));
             ModSettingsManager.AddOption(new StringInputFieldOption(TierOrder, new InputFieldConfig() { restartRequired = false, checkIfDisabled = CheckTierSort, lineType = TMPro.TMP_InputField.LineType.MultiLineSubmit, submitOn = InputFieldConfig.SubmitEnum.OnExitOrSubmit}));
+            ModSettingsManager.AddOption(new GenericButtonOption("Use Descending Tiers Preset", "Auto Sort Items", "Sets the Tier Order option to use descending tiers", "Set", SetDescendingTiers));
+            ModSettingsManager.AddOption(new GenericButtonOption("Use Ascending Tiers Preset", "Auto Sort Items", "Sets the Tier Order option to use ascending tiers", "Set", SetAscendingTiers));
             ModSettingsManager.AddOption(new CheckBoxOption(CombineVoidTiers, new CheckBoxConfig() { restartRequired = false, checkIfDisabled = CheckTierSort }));
             ModSettingsManager.AddOption(new CheckBoxOption(DescendingTier, new CheckBoxConfig() { restartRequired = false, checkIfDisabled = CheckTierSort }));
             ModSettingsManager.AddOption(new CheckBoxOption(SortByStackSize, new CheckBoxConfig() { restartRequired = false }));
@@ -150,6 +153,29 @@ namespace LookingGlass.AutoSortItems
         {
             return SortScrapperAlphabetical.Value;
         }
+
+        private void SetDescendingTiers()
+        {
+            // manually update the tier order option in the menu (which also updates the setting)
+            foreach (var controller in UnityEngine.Object.FindObjectsOfType<InputFieldController>())
+            {
+                if (controller.name.Contains("Tier Order"))
+                {
+                    controller.SubmitValue("Lunar VoidBoss Boss VoidTier3 Tier3 VoidTier2 Tier2 VoidTier1 Tier1");
+                }
+            }
+        }
+        private void SetAscendingTiers()
+        {
+            foreach (var controller in UnityEngine.Object.FindObjectsOfType<InputFieldController>())
+            {
+                if (controller.name.Contains("Tier Order"))
+                {
+                    controller.SubmitValue("Tier1 VoidTier1 Tier2 VoidTier2 Tier3 VoidTier3 Boss VoidBoss Lunar");
+                }
+            }
+        }
+
         internal void SortPickupPicker(PickupPickerController.Option[] options, ReadOnlyCollection<MPButton> elements, Inventory inventory, bool isCommand, PickupPickerPanel panel)
         {
             Dictionary<ItemIndex, GameObject> stuff = new Dictionary<ItemIndex, GameObject>();

--- a/LookingGlass/AutoSortItems/AutoSortItemsClass.cs
+++ b/LookingGlass/AutoSortItems/AutoSortItemsClass.cs
@@ -25,12 +25,10 @@ namespace LookingGlass.AutoSortItems
     internal class AutoSortItemsClass : BaseThing
     {
 
-        // TODO: figure out wtf to do with all the "descending" settings
         public static ConfigEntry<bool> SeperateScrap;
         public static ConfigEntry<bool> SortByTier;
         public static ConfigEntry<string> TierOrder;
         public static ConfigEntry<bool> CombineVoidTiers;
-        public static ConfigEntry<bool> DescendingTier;
         public static ConfigEntry<bool> SortByStackSize;
         public static ConfigEntry<bool> DescendingStackSize;
         public static ConfigEntry<bool> SortCommand;
@@ -38,7 +36,6 @@ namespace LookingGlass.AutoSortItems
         public static ConfigEntry<bool> SortCommandDescending;
         public static ConfigEntry<bool> SortScrapperDescending;
         public static ConfigEntry<bool> SortScrapperTier;
-        public static ConfigEntry<bool> SortScrapperTierDescending;
 
         public static ConfigEntry<bool> SortCommandAlphabetical;
         public static ConfigEntry<bool> SortScrapperAlphabetical;
@@ -66,7 +63,6 @@ namespace LookingGlass.AutoSortItems
             SortByTier = BasePlugin.instance.Config.Bind<bool>("Auto Sort Items", "Tier Sort", true, "Sorts by Tier");
             TierOrder = BasePlugin.instance.Config.Bind<string>("Auto Sort Items", "Tier Order", "Lunar VoidBoss Boss VoidTier3 Tier3 VoidTier2 Tier2 VoidTier1 Tier1", "How the tiers should be ordered");
             CombineVoidTiers = BasePlugin.instance.Config.Bind<bool>("Auto Sort Items", "Combine Normal And Void Tiers", false, "Considers void tiers to be the same as their normal counterparts");
-            DescendingTier = BasePlugin.instance.Config.Bind<bool>("Auto Sort Items", "Descending Tier Sort", true, "Sorts by Tier Descending");
             SortByStackSize = BasePlugin.instance.Config.Bind<bool>("Auto Sort Items", "Stack Size Sort", true, "Sorts by Stack Size");
             DescendingStackSize = BasePlugin.instance.Config.Bind<bool>("Auto Sort Items", "Descending Stack Size Sort", true, "Sorts by Stack Size Descending");
             SortCommand = BasePlugin.instance.Config.Bind<bool>("Auto Sort Items", "Sort Command Menu", true, "Sorts command menu by stack count");
@@ -74,7 +70,6 @@ namespace LookingGlass.AutoSortItems
             SortScrapper = BasePlugin.instance.Config.Bind<bool>("Auto Sort Items", "Sort Scrapper", true, "Sorts Scrapper by stack count");
             SortScrapperDescending = BasePlugin.instance.Config.Bind<bool>("Auto Sort Items", "Scrapper Descending", true, "Sorts Scrapper by descending");
             SortScrapperTier = BasePlugin.instance.Config.Bind<bool>("Auto Sort Items", "Sort Scrapper Tier", false, "Sorts Scrapper by tier");
-            SortScrapperTierDescending = BasePlugin.instance.Config.Bind<bool>("Auto Sort Items", "Scrapper Tier Descending", true, "Sorts Scrapper by descending");
 
             SortCommandAlphabetical = BasePlugin.instance.Config.Bind<bool>("Auto Sort Items", "Sort Command Menu Alphabetically", false, "Sorts command menu alphabetically");
             SortCommandAlphabeticalDescending = BasePlugin.instance.Config.Bind<bool>("Auto Sort Items", "Command Menu Alphabetically Descending", true, "Sorts command alphabetically descending");
@@ -84,7 +79,6 @@ namespace LookingGlass.AutoSortItems
             SortByTier.SettingChanged += SettingsChanged;
             TierOrder.SettingChanged += SettingsChanged;
             CombineVoidTiers.SettingChanged += SettingsChanged;
-            DescendingTier.SettingChanged += SettingsChanged;
             SortByStackSize.SettingChanged += SettingsChanged;
             DescendingStackSize.SettingChanged += SettingsChanged;
 
@@ -100,7 +94,6 @@ namespace LookingGlass.AutoSortItems
             ModSettingsManager.AddOption(new GenericButtonOption("Use Descending Tiers Preset", "Auto Sort Items", "Sets the Tier Order option to use descending tiers", "Set", SetDescendingTiers));
             ModSettingsManager.AddOption(new GenericButtonOption("Use Ascending Tiers Preset", "Auto Sort Items", "Sets the Tier Order option to use ascending tiers", "Set", SetAscendingTiers));
             ModSettingsManager.AddOption(new CheckBoxOption(CombineVoidTiers, new CheckBoxConfig() { restartRequired = false, checkIfDisabled = CheckTierSort }));
-            ModSettingsManager.AddOption(new CheckBoxOption(DescendingTier, new CheckBoxConfig() { restartRequired = false, checkIfDisabled = CheckTierSort }));
             ModSettingsManager.AddOption(new CheckBoxOption(SortByStackSize, new CheckBoxConfig() { restartRequired = false }));
             ModSettingsManager.AddOption(new CheckBoxOption(DescendingStackSize, new CheckBoxConfig() { restartRequired = false, checkIfDisabled = CheckStackSort }));
 
@@ -109,7 +102,6 @@ namespace LookingGlass.AutoSortItems
             ModSettingsManager.AddOption(new CheckBoxOption(SortScrapper, new CheckBoxConfig() { restartRequired = false, checkIfDisabled = CheckNotScrapperSortTierAlphabetical }));
             ModSettingsManager.AddOption(new CheckBoxOption(SortScrapperDescending, new CheckBoxConfig() { restartRequired = false, checkIfDisabled = CheckScrapperSort }));
             ModSettingsManager.AddOption(new CheckBoxOption(SortScrapperTier, new CheckBoxConfig() { restartRequired = false, checkIfDisabled = CheckNotScrapperSortTierAlphabetical }));
-            ModSettingsManager.AddOption(new CheckBoxOption(SortScrapperTierDescending, new CheckBoxConfig() { restartRequired = false, checkIfDisabled = CheckScrapperSortTier }));
 
             ModSettingsManager.AddOption(new CheckBoxOption(SortCommandAlphabetical, new CheckBoxConfig() { restartRequired = false }));
             ModSettingsManager.AddOption(new CheckBoxOption(SortCommandAlphabeticalDescending, new CheckBoxConfig() { restartRequired = false, checkIfDisabled = CheckCommandSortAlphabetical }));
@@ -203,7 +195,7 @@ namespace LookingGlass.AutoSortItems
             }
             else
             {
-                items = new List<ItemIndex>(SortItems(items.ToArray(), items.Count, display, false, isCommand ? false : SortScrapperTier.Value, isCommand ? false : SortScrapperTierDescending.Value, isCommand ? SortCommand.Value : SortScrapper.Value, isCommand ? SortCommandDescending.Value : SortScrapperDescending.Value));
+                items = new List<ItemIndex>(SortItems(items.ToArray(), items.Count, display, false, isCommand ? false : SortScrapperTier.Value, isCommand ? SortCommand.Value : SortScrapper.Value, isCommand ? SortCommandDescending.Value : SortScrapperDescending.Value));
             }
             foreach (var item in items)
             {
@@ -307,7 +299,7 @@ namespace LookingGlass.AutoSortItems
                     }
                     Log.Debug(Utils.DictToString(tierMatcher));
                 }
-                self.itemOrder = SortItems(self.itemOrder, self.itemOrderCount, self, SeperateScrap.Value, SortByTier.Value, DescendingTier.Value, SortByStackSize.Value, DescendingStackSize.Value);
+                self.itemOrder = SortItems(self.itemOrder, self.itemOrderCount, self, SeperateScrap.Value, SortByTier.Value, SortByStackSize.Value, DescendingStackSize.Value);
             }
             catch (Exception e)
             {
@@ -334,7 +326,7 @@ namespace LookingGlass.AutoSortItems
             }
         }
 
-        ItemIndex[] SortItems(ItemIndex[] items, int count, RoR2.UI.ItemInventoryDisplay display, bool seperateScrap, bool sortByTier, bool descendingTier, bool sortByStackSize, bool descendingStackSize) //This really should be refactored but it works so...
+        ItemIndex[] SortItems(ItemIndex[] items, int count, RoR2.UI.ItemInventoryDisplay display, bool seperateScrap, bool sortByTier, bool sortByStackSize, bool descendingStackSize) //This really should be refactored but it works so...
         {
             foreach (var tierList in itemTierLists)
             {
@@ -399,26 +391,12 @@ namespace LookingGlass.AutoSortItems
                         num++;
                     }
                 }
-                if (descendingTier)
+                for (int i = 0; i < itemTierLists.Count; i++)
                 {
-                    for (int i = itemTierLists.Count - 1; i > -1; i--)
+                    for (int x = 0; x < itemTierLists[i].Count; x++)
                     {
-                        for (int x = 0; x < itemTierLists[i].Count; x++)
-                        {
-                            items[num] = itemTierLists[i][x];
-                            num++;
-                        }
-                    }
-                }
-                else
-                {
-                    for (int i = 0; i < itemTierLists.Count; i++)
-                    {
-                        for (int x = 0; x < itemTierLists[i].Count; x++)
-                        {
-                            items[num] = itemTierLists[i][x];
-                            num++;
-                        }
+                        items[num] = itemTierLists[i][x];
+                        num++;
                     }
                 }
                 for (int i = 0; i < noTierList.Count; i++)

--- a/LookingGlass/AutoSortItems/AutoSortItemsClass.cs
+++ b/LookingGlass/AutoSortItems/AutoSortItemsClass.cs
@@ -65,7 +65,7 @@ namespace LookingGlass.AutoSortItems
             SeperateScrap = BasePlugin.instance.Config.Bind<bool>("Auto Sort Items", "Seperate Scrap", true, "Sorts by Scrap");
             SortByTier = BasePlugin.instance.Config.Bind<bool>("Auto Sort Items", "Tier Sort", true, "Sorts by Tier");
             TierOrder = BasePlugin.instance.Config.Bind<string>("Auto Sort Items", "Tier Order", "Lunar VoidBoss Boss VoidTier3 Tier3 VoidTier2 Tier2 VoidTier1 Tier1", "How the tiers should be ordered");
-            CombineVoidTiers = BasePlugin.instance.Config.Bind<bool>("Auto Sort Items", "Combine Void Tiers", false, "Considers void tiers to be the same as their normal counterparts");
+            CombineVoidTiers = BasePlugin.instance.Config.Bind<bool>("Auto Sort Items", "Combine Normal And Void Tiers", false, "Considers void tiers to be the same as their normal counterparts");
             DescendingTier = BasePlugin.instance.Config.Bind<bool>("Auto Sort Items", "Descending Tier Sort", true, "Sorts by Tier Descending");
             SortByStackSize = BasePlugin.instance.Config.Bind<bool>("Auto Sort Items", "Stack Size Sort", true, "Sorts by Stack Size");
             DescendingStackSize = BasePlugin.instance.Config.Bind<bool>("Auto Sort Items", "Descending Stack Size Sort", true, "Sorts by Stack Size Descending");

--- a/LookingGlass/AutoSortItems/AutoSortItemsClass.cs
+++ b/LookingGlass/AutoSortItems/AutoSortItemsClass.cs
@@ -24,8 +24,11 @@ namespace LookingGlass.AutoSortItems
     internal class AutoSortItemsClass : BaseThing
     {
 
+        // TODO: figure out wtf to do with all the "descending" settings
         public static ConfigEntry<bool> SeperateScrap;
         public static ConfigEntry<bool> SortByTier;
+        public static ConfigEntry<string> TierOrder;
+        public static ConfigEntry<bool> CombineVoidTiers;
         public static ConfigEntry<bool> DescendingTier;
         public static ConfigEntry<bool> SortByStackSize;
         public static ConfigEntry<bool> DescendingStackSize;
@@ -60,6 +63,8 @@ namespace LookingGlass.AutoSortItems
             instance = this;
             SeperateScrap = BasePlugin.instance.Config.Bind<bool>("Auto Sort Items", "Seperate Scrap", true, "Sorts by Scrap");
             SortByTier = BasePlugin.instance.Config.Bind<bool>("Auto Sort Items", "Tier Sort", true, "Sorts by Tier");
+            TierOrder = BasePlugin.instance.Config.Bind<string>("Auto Sort Items", "Tier Order", "Lunar VoidBoss Boss VoidTier3 Tier3 VoidTier2 Tier2 VoidTier1 Tier1", "How the tiers should be ordered");
+            CombineVoidTiers = BasePlugin.instance.Config.Bind<bool>("Auto Sort Items", "Combine Void Tiers", false, "Considers void tiers to be the same as their normal counterparts");
             DescendingTier = BasePlugin.instance.Config.Bind<bool>("Auto Sort Items", "Descending Tier Sort", true, "Sorts by Tier Descending");
             SortByStackSize = BasePlugin.instance.Config.Bind<bool>("Auto Sort Items", "Stack Size Sort", true, "Sorts by Stack Size");
             DescendingStackSize = BasePlugin.instance.Config.Bind<bool>("Auto Sort Items", "Descending Stack Size Sort", true, "Sorts by Stack Size Descending");
@@ -76,6 +81,8 @@ namespace LookingGlass.AutoSortItems
             SortScrapperAlphabeticalDescending = BasePlugin.instance.Config.Bind<bool>("Auto Sort Items", "Scrapper Alphabetically Descending", true, "Sorts Scrapper alphabetically descending");
             SeperateScrap.SettingChanged += SettingsChanged;
             SortByTier.SettingChanged += SettingsChanged;
+            TierOrder.SettingChanged += SettingsChanged;
+            CombineVoidTiers.SettingChanged += SettingsChanged;
             DescendingTier.SettingChanged += SettingsChanged;
             SortByStackSize.SettingChanged += SettingsChanged;
             DescendingStackSize.SettingChanged += SettingsChanged;
@@ -83,10 +90,13 @@ namespace LookingGlass.AutoSortItems
             InitHooks();
             SetupRiskOfOptions();
         }
+
         public void SetupRiskOfOptions()
         {
             ModSettingsManager.AddOption(new CheckBoxOption(SeperateScrap, new CheckBoxConfig() { restartRequired = false }));
             ModSettingsManager.AddOption(new CheckBoxOption(SortByTier, new CheckBoxConfig() { restartRequired = false }));
+            ModSettingsManager.AddOption(new StringInputFieldOption(TierOrder, new InputFieldConfig() { restartRequired = false, checkIfDisabled = CheckTierSort, lineType = TMPro.TMP_InputField.LineType.MultiLineSubmit, submitOn = InputFieldConfig.SubmitEnum.OnExitOrSubmit}));
+            ModSettingsManager.AddOption(new CheckBoxOption(CombineVoidTiers, new CheckBoxConfig() { restartRequired = false }));
             ModSettingsManager.AddOption(new CheckBoxOption(DescendingTier, new CheckBoxConfig() { restartRequired = false, checkIfDisabled = CheckTierSort }));
             ModSettingsManager.AddOption(new CheckBoxOption(SortByStackSize, new CheckBoxConfig() { restartRequired = false }));
             ModSettingsManager.AddOption(new CheckBoxOption(DescendingStackSize, new CheckBoxConfig() { restartRequired = false, checkIfDisabled = CheckStackSort }));
@@ -247,14 +257,27 @@ namespace LookingGlass.AutoSortItems
                 if (!initialized)
                 {
                     initialized = true;
-                    foreach (var tierList in RoR2.ContentManagement.ContentManager.itemTierDefs)
+                    tierMatcher.Clear();
+                    itemTierLists.Clear();
+                    foreach (string tierString in TierOrder.Value.Split(' '))
                     {
-                        if (tierList.tier.ToString() == "NoTier")
+                        if (Enum.TryParse(tierString, out ItemTier tier))
+                        {
+                            tierMatcher.Add(tier, itemTierLists.Count);
+                            itemTierLists.Add(new List<ItemIndex>());
+                        }
+                    }
+                    foreach (var tierDef in RoR2.ContentManagement.ContentManager.itemTierDefs)
+                    {
+                        if (tierDef.tier.ToString() == "NoTier")
                         {
                             noTierNum = itemTierLists.Count;
                         }
-                        tierMatcher.Add(tierList.tier, itemTierLists.Count);
-                        itemTierLists.Add(new List<ItemIndex>());
+                        if (!tierMatcher.ContainsKey(tierDef.tier)) // use default ordering for any not present in the setting (TODO: test this probably?)
+                        {
+                            tierMatcher.Add(tierDef.tier, itemTierLists.Count);
+                            itemTierLists.Add(new List<ItemIndex>());
+                        }
                     }
                 }
                 self.itemOrder = SortItems(self.itemOrder, self.itemOrderCount, self, SeperateScrap.Value, SortByTier.Value, DescendingTier.Value, SortByStackSize.Value, DescendingStackSize.Value);
@@ -271,6 +294,7 @@ namespace LookingGlass.AutoSortItems
 
         private void SettingsChanged(object sender, EventArgs e)
         {
+            initialized = false; // force re-initialization
             try
             {
                 if (display)
@@ -307,7 +331,20 @@ namespace LookingGlass.AutoSortItems
                     }
                     else
                     {
-                        itemTierLists[tierMatcher[ItemCatalog.GetItemDef(items[i]).tier]].Add(items[i]);
+                        ItemTier tier = ItemCatalog.GetItemDef(items[i]).tier;
+                        if (CombineVoidTiers.Value)
+                        {
+                            // pretend the item is the regular version of the tier
+                            tier = tier switch
+                            {
+                                ItemTier.VoidBoss => ItemTier.Boss,
+                                ItemTier.VoidTier3 => ItemTier.Tier3,
+                                ItemTier.VoidTier2 => ItemTier.Tier2,
+                                ItemTier.VoidTier1 => ItemTier.Tier1,
+                                _ => tier
+                            };
+                        }
+                        itemTierLists[tierMatcher[tier]].Add(items[i]);
                     }
                 }
                 else

--- a/LookingGlass/AutoSortItems/AutoSortItemsClass.cs
+++ b/LookingGlass/AutoSortItems/AutoSortItemsClass.cs
@@ -31,7 +31,6 @@ namespace LookingGlass.AutoSortItems
             Mixed
         }
 
-        //public static ConfigEntry<bool> SeperateScrap;
         public static ConfigEntry<ScrapSortMode> ScrapSorting;
         public static ConfigEntry<bool> SortByTier;
         public static ConfigEntry<string> TierOrder;

--- a/LookingGlass/Utils.cs
+++ b/LookingGlass/Utils.cs
@@ -1,5 +1,6 @@
 ﻿using RoR2;
 using System;
+using System.Collections.Generic;
 using UnityEngine;
 
 namespace LookingGlass
@@ -52,6 +53,17 @@ namespace LookingGlass
         public static float GetBandolierStacking(int count)
         {
             return 1f - 1f / Mathf.Pow(1f + count, 0.33f);
+        }
+
+        public static string DictToString<TKey, TValue>(Dictionary<TKey, TValue> dict)
+        {
+            string s = "{\n";
+            foreach (KeyValuePair<TKey, TValue> kv in dict)
+            {
+                s += $"[{kv.Key}] = {kv.Value}\n";
+            }
+            s += "}";
+            return s;
         }
     }
 }


### PR DESCRIPTION
Bit of a bigger feature this time, this overhauls the sorting settings to be more customizable.

- **Tier Order:** A string setting that allows you to define the order in which item tiers should be sorted, with each tier separated by a space. Duplicate or invalid tiers are simply ignored, and missing tiers are added afterward according to the game's internal tier ordering. Defaults to `Lunar VoidBoss Boss VoidTier3 Tier3 VoidTier2 Tier2 VoidTier1 Tier1`. This ***replaces*** the Tier Descending settings.
- **Tier Order Preset Buttons:** Allows you to choose between two presets for the Tier Order option, descending (same as default) and ascending (reverse of default). Mostly for convenience since I killed the Tier Descending checkbox, as well as a convenient way to get back to the default if you somehow mess up the setting.
- **Combine Normal and Void Tiers:** This causes void items to be sorted alongside their normal tiers (e.g. Lysate Cell is sorted as if it were a normal green item) instead of being considered separate tiers.
- **Scrap Sorting:** Replaces the "Separate Scrap" checkbox with a tri-state setting, with `Start`, `End`, and `Mixed` options. I also made it so that scrap always respects your tier sorting settings.

Code-wise, the things worth pointing out / commenting on are:
- the removal of the `descendingTier` param of `SortItems` (no, I didn't refactor it more thoroughly... sorry :P)
- changing the sorting settings now sets `initialized` to false, which re-populates `tierMatcher` and `itemTierLists` from scratch (yes I made sure this also clears them first)
- the preset buttons have to manually change the RiskOfOptions input field, just changing the value of the setting isn't enough
- using `CombineVoidTiers` just makes it pretend that void items are the corresponding normal tier at sorting time
- the `DictToString` method I added to Utils is for a debug log that shows the state of `tierMatcher` after initialization is done... maybe this could be removed, but I also think it might not be a terrible idea to leave in, shouldn't be _too_ spammy since it should only print once on first run start or after changing settings
  - also, if you see a tier simply labeled as `11`, that's the equipment tier, which doesn't have an entry in the `ItemTier` enum (and _should_ never show up in the inventory anyway)

Considerations / known issues:
- I also removed the "Sort Scrapper Tier Descending" setting as part of the overhaul, since it seemed a bit out of place now (it'd just reverse the order set in the tier order option). This is _technically_ a regression, since you can no longer sort tiers in the scrapper differently from in the inventory. There could be a "Scrapper Tier Order" setting if this is considered important, but I didn't want to put in the effort without knowing if anyone even cares about that.
- Sometimes (seemingly randomly), changing the sort settings in the Risk of Options menu doesn't immediately update the inventory display in-game. I'm not sure why, since it's definitely still running the initialization and sorting code for the inventory display, it's just not changing the UI. It does seem to always update properly when picking up a new item or changing stages, though.
- Is it a good idea to change the default tier ordering like I have? I'm inclined to say this is a better default than the reverse of the game's internal tier ordering, but I might also be biased... or maybe I'm just overthinking things and it's not a big deal 😅