### PR TITLE
Fixed items with no descriptions

### DIFF
--- a/LookingGlass/ItemStats/ItemStats.cs
+++ b/LookingGlass/ItemStats/ItemStats.cs
@@ -151,6 +151,10 @@ namespace LookingGlass.ItemStatsNameSpace
         }
         public static string GetDescription(ItemDef itemDef, ItemIndex newItemIndex, int newItemCount, CharacterMaster master, bool withOneMore)
         {
+            if (Language.GetString(itemDef.descriptionToken) == itemDef.descriptionToken)
+            {
+                return Language.GetString(itemDef.pickupToken);
+            }
             var itemDescription = $"<size={itemStatsFontSize.Value}%>{Language.GetString(itemDef.descriptionToken)}\n";
             try
             {


### PR DESCRIPTION
Some items do not have description (#53). This code uses pickup text when item does not have a description.