### PR TITLE
"Show Corrupted Items" command menu feature

### DIFF
--- a/LookingGlass/CommandItemCount/CommandItemCount.cs
+++ b/LookingGlass/CommandItemCount/CommandItemCount.cs
@@ -144,6 +144,14 @@ namespace LookingGlass.CommandItemCount
                     content.overrideBodyText = stats;
                 }
             }
+            else if (isItem && corrupted)
+            {
+                string stats = $"<size=85%><color=#808080>{Language.GetString(itemDefinition.descriptionToken)}</color></style></size>";
+                ItemDef corruptedItemDefinition = ItemCatalog.GetItemDef(ContagiousItemManager.GetTransformedItemIndex(pickupDefinition.itemIndex));
+                stats += $"\n\nHas been corrupted by: <style=cIsVoid>{Language.GetString(corruptedItemDefinition.nameToken)}</style>\n\n";
+                stats += Language.GetString(corruptedItemDefinition.descriptionToken);
+                content.overrideBodyText = stats;
+            }
 
             TooltipProvider tooltipProvider = parent.gameObject.AddComponent<TooltipProvider>();
 


### PR DESCRIPTION
Another pretty neat feature if I do say so myself! This makes a couple changes to the item picker menus:
- When item counts are on, having 0 stacks of an item shows a grayed out "x0" instead of not having a number at all. Comes with an option to disable. This helps a little with visual consistency IMO, but was primarily to assist with the main feature...
- **Show Corrupted Items:** A new setting. If you have corrupted versions of an item, it'll show the count + description for the corrupted version underneath the normal ones, as well as showing stats for the corrupted version instead of the normal version.

It's probably easiest to understand with a picture:
<img src="https://github.com/Wet-Boys/LookingGlass/assets/5523379/1a924035-bf11-49a7-9eab-79f399729eb6" width="550"/>

Tested and working with modded void items as well (or at least the ones from Spikestrip and Tinker's Satchel). I'm not totally sure what happens if you have mods that add multiple void variants of the same item, but I'm not sure how the game handles that _normally,_ so...

I also don't love the fact that the color formatting in the item description overrides the graying-out of the text, but I don't think there's a clean way to strip rich text tags from a string and I'm not sure if it's worth doing manually.