### PR TITLE
Uncomment a bunch of stat definitions

### DIFF
--- a/LookingGlass/ItemStats/ItemDefinitions.cs
+++ b/LookingGlass/ItemStats/ItemDefinitions.cs
@@ -53,17 +53,17 @@ namespace LookingGlass.ItemStatsNameSpace
 
 
             //Backup Magazine
-            //itemStat = new ItemStatsDef();
-            //itemStat.descriptions.Add("Skill Charges: ");
-            //itemStat.valueTypes.Add(ItemStatsDef.ValueType.Utility);
-            //itemStat.measurementUnits.Add(ItemStatsDef.MeasurementUnits.Number);
-            //itemStat.calculateValues = (luck, stackCount, procChance) =>
-            //{
-            //    List<float> values = new();
-            //    values.Add(stackCount);
-            //    return values;
-            //};
-            //allItemDefinitions.Add((int)RoR2Content.Items.SecondarySkillMagazine.itemIndex, itemStat);
+            itemStat = new ItemStatsDef();
+            itemStat.descriptions.Add("Skill Charges: ");
+            itemStat.valueTypes.Add(ItemStatsDef.ValueType.Utility);
+            itemStat.measurementUnits.Add(ItemStatsDef.MeasurementUnits.Number);
+            itemStat.calculateValuesNew = (luck, stackCount, procChance) =>
+            {
+                List<float> values = new();
+                values.Add(stackCount);
+                return values;
+            };
+            allItemDefinitions.Add((int)RoR2Content.Items.SecondarySkillMagazine.itemIndex, itemStat);
 
 
             //Bison Steak
@@ -307,17 +307,17 @@ namespace LookingGlass.ItemStatsNameSpace
 
 
             //Power Elixir
-            //itemStat = new ItemStatsDef();
-            //itemStat.descriptions.Add("Charges: ");
-            //itemStat.valueTypes.Add(ItemStatsDef.ValueType.Utility);
-            //itemStat.measurementUnits.Add(ItemStatsDef.MeasurementUnits.Number);
-            //itemStat.calculateValues = (luck, stackCount, procChance) =>
-            //{
-            //    List<float> values = new();
-            //    values.Add(stackCount);
-            //    return values;
-            //};
-            //allItemDefinitions.Add((int)DLC1Content.Items.HealingPotion.itemIndex, itemStat);
+            itemStat = new ItemStatsDef();
+            itemStat.descriptions.Add("Charges: ");
+            itemStat.valueTypes.Add(ItemStatsDef.ValueType.Utility);
+            itemStat.measurementUnits.Add(ItemStatsDef.MeasurementUnits.Number);
+            itemStat.calculateValuesNew = (luck, stackCount, procChance) =>
+            {
+                List<float> values = new();
+                values.Add(stackCount);
+                return values;
+            };
+            allItemDefinitions.Add((int)DLC1Content.Items.HealingPotion.itemIndex, itemStat);
 
 
             //Repulsion Armor Plate
@@ -349,17 +349,17 @@ namespace LookingGlass.ItemStatsNameSpace
 
 
             //Rusted Key
-            //itemStat = new ItemStatsDef();
-            //itemStat.descriptions.Add("Charges: ");
-            //itemStat.valueTypes.Add(ItemStatsDef.ValueType.Utility);
-            //itemStat.measurementUnits.Add(ItemStatsDef.MeasurementUnits.Number);
-            //itemStat.calculateValues = (luck, stackCount, procChance) =>
-            //{
-            //    List<float> values = new();
-            //    values.Add(stackCount);
-            //    return values;
-            //};
-            //allItemDefinitions.Add((int)RoR2Content.Items.TreasureCache.itemIndex, itemStat);
+            itemStat = new ItemStatsDef();
+            itemStat.descriptions.Add("Charges: ");
+            itemStat.valueTypes.Add(ItemStatsDef.ValueType.Utility);
+            itemStat.measurementUnits.Add(ItemStatsDef.MeasurementUnits.Number);
+            itemStat.calculateValuesNew = (luck, stackCount, procChance) =>
+            {
+                List<float> values = new();
+                values.Add(stackCount);
+                return values;
+            };
+            allItemDefinitions.Add((int)RoR2Content.Items.TreasureCache.itemIndex, itemStat);
 
 
             //Soldier's Syringe
@@ -751,17 +751,17 @@ namespace LookingGlass.ItemStatsNameSpace
 
 
             ////Regenerating Scrap
-            //itemStat = new ItemStatsDef();
-            //itemStat.descriptions.Add("Charges: ");
-            //itemStat.valueTypes.Add(ItemStatsDef.ValueType.Utility);
-            //itemStat.measurementUnits.Add(ItemStatsDef.MeasurementUnits.Number);
-            //itemStat.calculateValues = (luck, stackCount, procChance) =>
-            //{
-            //    List<float> values = new();
-            //    values.Add(stackCount);
-            //    return values;
-            //};
-            //allItemDefinitions.Add((int)ItemCatalog.FindItemIndex("RegeneratingScrap"), itemStat);
+            itemStat = new ItemStatsDef();
+            itemStat.descriptions.Add("Charges: ");
+            itemStat.valueTypes.Add(ItemStatsDef.ValueType.Utility);
+            itemStat.measurementUnits.Add(ItemStatsDef.MeasurementUnits.Number);
+            itemStat.calculateValuesNew = (luck, stackCount, procChance) =>
+            {
+                List<float> values = new();
+                values.Add(stackCount);
+                return values;
+            };
+            allItemDefinitions.Add((int)ItemCatalog.FindItemIndex("RegeneratingScrap"), itemStat);
 
 
             //Rose Buckler
@@ -983,17 +983,17 @@ namespace LookingGlass.ItemStatsNameSpace
 
 
             //Bottled Chaos
-            //itemStat = new ItemStatsDef();
-            //itemStat.descriptions.Add("Random Effects: ");
-            //itemStat.valueTypes.Add(ItemStatsDef.ValueType.Damage);
-            //itemStat.measurementUnits.Add(ItemStatsDef.MeasurementUnits.Number);
-            //itemStat.calculateValues = (luck, stackCount, procChance) =>
-            //{
-            //    List<float> values = new();
-            //    values.Add(stackCount);
-            //    return values;
-            //};
-            //allItemDefinitions.Add((int)DLC1Content.Items.RandomEquipmentTrigger.itemIndex, itemStat);
+            itemStat = new ItemStatsDef();
+            itemStat.descriptions.Add("Random Effects: ");
+            itemStat.valueTypes.Add(ItemStatsDef.ValueType.Damage);
+            itemStat.measurementUnits.Add(ItemStatsDef.MeasurementUnits.Number);
+            itemStat.calculateValuesNew = (luck, stackCount, procChance) =>
+            {
+                List<float> values = new();
+                values.Add(stackCount);
+                return values;
+            };
+            allItemDefinitions.Add((int)DLC1Content.Items.RandomEquipmentTrigger.itemIndex, itemStat);
 
 
             //Brainstalks
@@ -1592,15 +1592,15 @@ namespace LookingGlass.ItemStatsNameSpace
 
 
             //Defiant Gouge
-            //itemStat = new ItemStatsDef();
-            //itemStat.descriptions.Add("Enemy Strength: ");
-            //itemStat.valueTypes.Add(ItemStatsDef.ValueType.Utility);
-            //itemStat.measurementUnits.Add(ItemStatsDef.MeasurementUnits.Number);
-            //itemStat.calculateValues = (luck, stackCount, procChance) =>
-            //{
-            //    return new List<float>([stackCount]);
-            //};
-            //allItemDefinitions.Add((int)RoR2Content.Items.MonstersOnShrineUse.itemIndex, itemStat);
+            itemStat = new ItemStatsDef();
+            itemStat.descriptions.Add("Enemy Strength: ");
+            itemStat.valueTypes.Add(ItemStatsDef.ValueType.Utility);
+            itemStat.measurementUnits.Add(ItemStatsDef.MeasurementUnits.Number);
+            itemStat.calculateValuesNew = (luck, stackCount, procChance) =>
+            {
+                return new List<float>([stackCount]);
+            };
+            allItemDefinitions.Add((int)RoR2Content.Items.MonstersOnShrineUse.itemIndex, itemStat);
 
 
             //Egocentrism
@@ -1856,15 +1856,15 @@ namespace LookingGlass.ItemStatsNameSpace
 
 
             ////Encrusted Key
-            //itemStat = new ItemStatsDef();
-            //itemStat.descriptions.Add("Charges: ");
-            //itemStat.valueTypes.Add(ItemStatsDef.ValueType.Utility);
-            //itemStat.measurementUnits.Add(ItemStatsDef.MeasurementUnits.Number);
-            //itemStat.calculateValues = (luck, stackCount, procChance) =>
-            //{
-            //    return new List<float>([stackCount]);
-            //};
-            //allItemDefinitions.Add((int)DLC1Content.Items.TreasureCacheVoid.itemIndex, itemStat);
+            itemStat = new ItemStatsDef();
+            itemStat.descriptions.Add("Charges: ");
+            itemStat.valueTypes.Add(ItemStatsDef.ValueType.Utility);
+            itemStat.measurementUnits.Add(ItemStatsDef.MeasurementUnits.Number);
+            itemStat.calculateValuesNew = (luck, stackCount, procChance) =>
+            {
+                return new List<float>([stackCount]);
+            };
+            allItemDefinitions.Add((int)DLC1Content.Items.TreasureCacheVoid.itemIndex, itemStat);
 
 
             //Lost Seer's Lenses

--- a/LookingGlass/ItemStats/ItemDefinitions.cs
+++ b/LookingGlass/ItemStats/ItemDefinitions.cs
@@ -1595,7 +1595,7 @@ namespace LookingGlass.ItemStatsNameSpace
             itemStat = new ItemStatsDef();
             itemStat.descriptions.Add("Enemy Strength: ");
             itemStat.valueTypes.Add(ItemStatsDef.ValueType.Utility);
-            itemStat.measurementUnits.Add(ItemStatsDef.MeasurementUnits.Number);
+            itemStat.measurementUnits.Add(ItemStatsDef.MeasurementUnits.Percentage);
             itemStat.calculateValuesNew = (luck, stackCount, procChance) =>
             {
                 return new List<float>([stackCount]);


### PR DESCRIPTION
For some reason #70 (specifically https://github.com/Wet-Boys/LookingGlass/pull/70/commits/550bf424279e9362d3f15e37e5a26c2f9af51788) commented out a bunch of item stat definitions, so they won't show any stats ingame. I'm not sure why exactly, maybe because all those particular items stack trivially and it was deemed not necessary? Regardless, I think it's better to be consistent and show stats for all vanilla items - I really thought this was a bug at first.

(While I was at it I also changed Defiant Gouge to show enemy strength as a percentage rather than as a flat number.)