### PR TITLE
Fix tier sorting being broken with Consumed Regenerating Scrap

### DIFF
--- a/LookingGlass/AutoSortItems/AutoSortItemsClass.cs
+++ b/LookingGlass/AutoSortItems/AutoSortItemsClass.cs
@@ -390,7 +390,14 @@ namespace LookingGlass.AutoSortItems
                 }
                 if (scrapList.Count >= 0)
                 {
-                    scrapList = scrapList.OrderBy(item => tierMatcher[ItemCatalog.GetItemDef(item).tier]).ToList();
+                    scrapList = scrapList.OrderBy(item =>
+                    {
+                        if (tierMatcher.TryGetValue(ItemCatalog.GetItemDef(item).tier, out int value))
+                        {
+                            return value;
+                        }
+                        return 999;
+                    }).ToList();
                 }
                 int num = 0;
                 if (seperateScrap && ScrapSorting.Value == ScrapSortMode.Start)


### PR DESCRIPTION
~~I made an oopsies in #80 and didn't test Consumed Regenerating Scrap, which breaks sorting because it's considered a scrap item but is `NoTier`, so it errors out when it tries to access `tierMatcher[ItemTier.NoTier]`. There's probably a better way to fix this (like making `NoTier` a proper sortable tier) but this works as a quick hotfix.~~

Ignore this, superseded by #90.