### PR TITLE
Fixed pickup description for items with no description

### DIFF
--- a/LookingGlass/ItemStats/ItemStats.cs
+++ b/LookingGlass/ItemStats/ItemStats.cs
@@ -106,7 +106,14 @@ namespace LookingGlass.ItemStatsNameSpace
         {
             orig(self, itemDef);
             if (fullDescOnPickup.Value)
-                self.descriptionText.token = itemDef.descriptionToken;
+                if (Language.GetString(itemDef.descriptionToken) == itemDef.descriptionToken)
+                {
+                    self.descriptionText.token = itemDef.pickupToken;
+                }
+                else
+                {
+                    self.descriptionText.token = itemDef.descriptionToken;
+                }
         }
         void EquipmentText(Action<GenericNotification, EquipmentDef> orig, GenericNotification self, EquipmentDef equipmentDef)
         {


### PR DESCRIPTION
Forces the game to use pickupToken for description when descriptionToken does not return description. Finished addressing #53. 

I did not check if it worked on pickup earlier and it only did when hovering over an item in the inventory (sorry >_<). This should do it for picking up a new item, including when the bottle is broken