### PR TITLE
Make "Show Corrupted Items" also work the other way

### DIFF
--- a/LookingGlass/CommandItemCount/CommandItemCount.cs
+++ b/LookingGlass/CommandItemCount/CommandItemCount.cs
@@ -201,7 +201,7 @@ namespace LookingGlass.CommandItemCount
                 }
                 else if (corruption.Type == CorruptionType.Void)
                 {
-                    stats = ItemStats.GetDescription(itemDefinition, itemDefinition.itemIndex, corruption.ItemCount, null, withOneMore);
+                    stats = ItemStats.GetDescription(itemDefinition, itemDefinition.itemIndex, corruption.ItemCount, null, withOneMore, true);
                 }
                 else
                 {

--- a/LookingGlass/CommandItemCount/ItemCorruptionInfo.cs
+++ b/LookingGlass/CommandItemCount/ItemCorruptionInfo.cs
@@ -1,0 +1,19 @@
+﻿using RoR2;
+using System.Collections.Generic;
+
+namespace LookingGlass.CommandItemCount
+{
+    internal enum CorruptionType
+    {
+        None,
+        Corrupted, // item is corrupted by something else
+        Void // this item is corrupting other items
+    }
+
+    internal class ItemCorruptionInfo
+    {
+        public CorruptionType Type;
+        public List<ItemIndex> Items;
+        public int ItemCount;
+    }
+}

--- a/LookingGlass/ItemStats/ItemStats.cs
+++ b/LookingGlass/ItemStats/ItemStats.cs
@@ -313,7 +313,8 @@ namespace LookingGlass.ItemStatsNameSpace
                 self.tooltipProvider.overrideBodyText = GetDescription(itemDef, newItemIndex, newItemCount, master, false);
             }
         }
-        public static string GetDescription(ItemDef itemDef, ItemIndex newItemIndex, int newItemCount, CharacterMaster master, bool withOneMore)
+        public static string GetDescription(
+            ItemDef itemDef, ItemIndex newItemIndex, int newItemCount, CharacterMaster master, bool withOneMore, bool forceNew = false)
         {
             if (Language.GetString(itemDef.descriptionToken) == itemDef.descriptionToken)
             {
@@ -327,7 +328,14 @@ namespace LookingGlass.ItemStatsNameSpace
                     ItemStatsDef itemStats = ItemDefinitions.allItemDefinitions[(int)newItemIndex];
                     if (withOneMore && itemStats.descriptions.Count != 0)
                     {
-                        itemDescription += $"\nWith one more stack, you will have:";
+                        if (newItemCount == 0 || forceNew)
+                        {
+                            itemDescription += $"\nWith this item, you will have:";
+                        }
+                        else
+                        {
+                            itemDescription += $"\nWith another stack, you will have:";
+                        }
                         newItemCount++;
                     }
                     if (master == null)


### PR DESCRIPTION
After I was finished with Show Corrupted Items for the command menu I realized it should probably work the other way too - if you're about to choose a void item, it should show how many of the corresponding normal item you have. So, I did that.

<img src="https://github.com/user-attachments/assets/7cb2c944-9b9a-4047-a1c3-5412f59f5c9d" width="550"/>

The specific internal changes worth noting are:

- a hook on `ContagiousItemManager.InitTransformationTable` to create a one-to-many `transformedToOriginal` lookup dict, which the game does not seem to have by itself
- the creation of a new `ItemCorruptionInfo` class to pass around data, which seems cleaner than having a bunch of extra parameters
  - also a `CorruptionType` enum since now we need to handle going both ways

Also I changed the "with one more" message again:
- if you already have the item, it now says "With another stack" instead of "With one more stack" because it sounds slightly more "professional" i think? idk really
- if you don't already have the item, it now says "With this item" instead