### PR TITLE
fix Purity cooldown calculations being broken

### DIFF
--- a/LookingGlass/ItemStats/ItemStats.cs
+++ b/LookingGlass/ItemStats/ItemStats.cs
@@ -256,7 +256,7 @@ namespace LookingGlass.ItemStatsNameSpace
 
             if (badLuckCount > 0)
             {
-                calculated_skill_cooldown -= ItemDefinitions.allItemDefinitions[(int)RoR2Content.Items.LunarBadLuck.itemIndex].calculateValues(body.master, badLuckCount)[0];
+                calculated_skill_cooldown -= ItemDefinitions.allItemDefinitions[(int)RoR2Content.Items.LunarBadLuck.itemIndex].calculateValuesNew(0, badLuckCount, 1)[0];
             }
 
             if (calculated_skill_cooldown < 0.5f)


### PR DESCRIPTION
Changes Purity cooldown calculations to use `calculateValuesNew`, since `calculateValues` was removed. This is also causing NullReferenceException log spam so would be cool to have this in soon. (I know I can merge it myself but I don't have perms to upload to Thunderstore and wouldn't know how to use them even if I did so I don't feel there's much of a point lol)