### PR TITLE
add "Cap Chance Percentage" setting

### DIFF
--- a/LookingGlass/ItemStats/ItemStats.cs
+++ b/LookingGlass/ItemStats/ItemStats.cs
@@ -27,6 +27,7 @@ namespace LookingGlass.ItemStatsNameSpace
         public static ConfigEntry<bool> fullDescOnPickup;
         public static ConfigEntry<bool> itemStatsOnPing;
         public static ConfigEntry<float> itemStatsFontSize;
+        public static ConfigEntry<bool> capChancePercentage;
 
         private static Hook overrideHook;
         private static Hook overrideHook2;
@@ -45,6 +46,7 @@ namespace LookingGlass.ItemStatsNameSpace
             fullDescOnPickup = BasePlugin.instance.Config.Bind<bool>("Misc", "Full Item Description On Pickup", true, "Shows full item descriptions on pickup");
             itemStatsOnPing = BasePlugin.instance.Config.Bind<bool>("Misc", "Item Stats On Ping", true, "Shows item descriptions when you ping an item in the world");
             itemStatsFontSize = BasePlugin.instance.Config.Bind<float>("Misc", "Item Stats Font Size", 100f, "Changes the font size of item stats");
+            capChancePercentage = BasePlugin.instance.Config.Bind<bool>("Misc", "Cap Chance Percentage", true, "Caps displayed chances at 100%. May interact weirdly with luck if turned off");
             SetupRiskOfOptions();
         }
         public void SetupRiskOfOptions()
@@ -54,6 +56,7 @@ namespace LookingGlass.ItemStatsNameSpace
             ModSettingsManager.AddOption(new CheckBoxOption(fullDescOnPickup, new CheckBoxConfig() { restartRequired = false }));
             ModSettingsManager.AddOption(new CheckBoxOption(itemStatsOnPing, new CheckBoxConfig() { restartRequired = false }));
             ModSettingsManager.AddOption(new SliderOption(itemStatsFontSize, new SliderConfig() { restartRequired = false, min = 1, max = 300 }));
+            ModSettingsManager.AddOption(new CheckBoxOption(capChancePercentage, new CheckBoxConfig() { restartRequired = false }));
         }
         private static bool ItemStatsDisabled()
         {

--- a/LookingGlass/Utils.cs
+++ b/LookingGlass/Utils.cs
@@ -1,4 +1,5 @@
-﻿using RoR2;
+﻿using LookingGlass.ItemStatsNameSpace;
+using RoR2;
 using System;
 using System.Collections.Generic;
 using UnityEngine;
@@ -17,12 +18,17 @@ namespace LookingGlass
 
         public static float CalculateChanceWithLuck(float baseChance, float luckIn)
         {
-            baseChance = Mathf.Min(baseChance, 1);
+            if (ItemStats.capChancePercentage.Value)
+            {
+                baseChance = Mathf.Min(baseChance, 1);
+            }
+            float chanceFloored = Mathf.Floor(baseChance);
+            float chanceMod = baseChance % 1f;
             int luck = Mathf.CeilToInt(luckIn);
             if (luck > 0)
-                return 1f - Mathf.Pow(1f - baseChance, luck + 1);
+                return chanceFloored + (1f - Mathf.Pow(1f - chanceMod, luck + 1));
             if (luck < 0)
-                return Mathf.Pow(baseChance, Mathf.Abs(luck) + 1);
+                return chanceFloored + Mathf.Pow(chanceMod, Mathf.Abs(luck) + 1);
 
             return baseChance;
         }


### PR DESCRIPTION
As requested in #92, this makes chances capping at 100% a configurable option, on by default but can now be turned off to let chances go above 100%. For interactions with luck I just chose to match BetterUI's behavior, which is effectively to modulo the chance before applying luck calculations to it (so for instance with +1 luck, 10% chance becomes 19% and 50% becomes 75%, so to match that a 110% chance becomes 119% and a 150% chance becomes 175%).