### PR TITLE
Fix cooldown values not receiving reductions from non-vanilla items

### DIFF
--- a/LookingGlass/EquipTimerFix/CooldownFixer.cs
+++ b/LookingGlass/EquipTimerFix/CooldownFixer.cs
@@ -63,7 +63,7 @@ namespace LookingGlass.EquipTimerFix
                 self.cooldownText)
             {
                 SkillIcon.sharedStringBuilder.Clear();
-                SkillIcon.sharedStringBuilder.AppendInt(Mathf.CeilToInt(self.targetSkill.cooldownRemaining), 1U, 1U);
+                SkillIcon.sharedStringBuilder.AppendInt(Mathf.CeilToInt(self.targetSkill.cooldownRemaining), 1U, uint.MaxValue);
                 self.cooldownText.SetText(SkillIcon.sharedStringBuilder);
                 self.cooldownText.gameObject.SetActive(true);
             }

--- a/LookingGlass/EquipTimerFix/CooldownFixer.cs
+++ b/LookingGlass/EquipTimerFix/CooldownFixer.cs
@@ -63,7 +63,7 @@ namespace LookingGlass.EquipTimerFix
                 self.cooldownText)
             {
                 SkillIcon.sharedStringBuilder.Clear();
-                SkillIcon.sharedStringBuilder.AppendInt(Mathf.CeilToInt(self.targetSkill.cooldownRemaining), 1U, uint.MaxValue);
+                SkillIcon.sharedStringBuilder.AppendInt(Mathf.CeilToInt(self.targetSkill.cooldownRemaining), 1U, 1U);
                 self.cooldownText.SetText(SkillIcon.sharedStringBuilder);
                 self.cooldownText.gameObject.SetActive(true);
             }


### PR DESCRIPTION
Changed the logic behind skill cooldown calculations to work with the skill's saved scaling values instead of checking player inventory for certain vanilla items. I'm pretty sure % CDR is applied before flat CDR, so I did baseCD * %CDR - flatCDR.

Also formatted the float result to 2 decimal places (0.00).

![image](https://github.com/user-attachments/assets/13317e97-5663-49be-b531-3b5a20b9780d)