### PR TITLE
Adjust equipment description and saferSpacesCD stat display def string

### DIFF
--- a/LookingGlass/ItemStats/ItemStats.cs
+++ b/LookingGlass/ItemStats/ItemStats.cs
@@ -106,7 +106,7 @@ namespace LookingGlass.ItemStatsNameSpace
                 String currentCooldownFormatted = (self.currentDisplayData.equipmentDef.cooldown * body.inventory.CalculateEquipmentCooldownScale()).ToString(StatsDisplayDefinitions.floatPrecision);
                 
                 self.tooltipProvider.overrideBodyText = $"{Language.GetString(self.currentDisplayData.equipmentDef.descriptionToken)}" +
-                    $"\nCooldown Reduction: <style=\"cIsUtility>{cooldownReductionFormatted}%</style>" +
+                    $"\n\nCooldown Reduction: <style=\"cIsUtility>{cooldownReductionFormatted}%</style>" +
                     $"\nCooldown: <style=\"cIsUtility>{currentCooldownFormatted} seconds</style>";
             }
 #pragma warning restore Publicizer001 // Accessing a member that was not originally public

--- a/LookingGlass/StatsDisplay/StatsDisplayDefinitions.cs
+++ b/LookingGlass/StatsDisplay/StatsDisplayDefinitions.cs
@@ -132,7 +132,7 @@ namespace LookingGlass.StatsDisplay
                 {
                     return $"{utilityString}N/A{styleString}";
                 }
-                return $"{utilityString}{(15 * Mathf.Pow(.9f, stackCount)).ToString(floatPrecision)}{styleString}";
+                return $"{utilityString}{(15 * Mathf.Pow(.9f, stackCount)).ToString(floatPrecision)}s{styleString}";
             });
             StatsDisplayClass.statDictionary.Add("instaKillChance", cachedUserBody => {
                 int stackCount = cachedUserBody.inventory.GetItemCount(DLC1Content.Items.CritGlassesVoid);


### PR DESCRIPTION
1. Add unit to `saferSpacesCD` stat display def string
    - Append `s` *(for seconds)* to the end of the string for Safer Spaces cooldown, similar to how Tougher Times appends `%`.
    - This should be done in the definition rather than the stats display string config option, since:
        - using the definition would allow the default styling colour to be applied
        - using the config option would yield `N/As` rather than just `N/A`
2. Separate equipment description from stats
    - Add an additional newline between the equipment's description and the cooldown stats
        - Improve readability
        - Make consistent with item tooltips
