### PR TITLE
Restructure PickupPickerPanel sorting (scrappers, command, etc..) to work better in multiplayer

### DIFF
--- a/LookingGlass/AutoSortItems/AutoSortItemsClass.cs
+++ b/LookingGlass/AutoSortItems/AutoSortItemsClass.cs
@@ -183,7 +183,7 @@ namespace LookingGlass.AutoSortItems
         internal (PickupPickerController.Option[], List<int>) SortPickupPicker(PickupPickerController.Option[] options, bool isCommand)
         {
             List<ItemIndex> items = new List<ItemIndex>();
-            List<ItemIndex> unSortedItems = new List<ItemIndex>();
+            List<ItemIndex> unSortedItems = new List<ItemIndex>(); //used to make mapping of what changed when sorting
             List<int> mapping = new List<int>(options.Length);
 
             for (int i = 0; i < options.Length; i++)
@@ -214,21 +214,12 @@ namespace LookingGlass.AutoSortItems
             }
 
             // make mapping of what was changed
-            mapping = Enumerable.ToList<int>(
-                Enumerable.Select<ItemIndex, int>
-                (items, (ItemIndex item) => unSortedItems.IndexOf(item))
-            );
+            mapping = Enumerable.ToList(Enumerable.Select(items, (ItemIndex item) => unSortedItems.IndexOf(item)));
 
+            // apply mapping to options
+            PickupPickerController.Option[] sortedOptions = Enumerable.ToArray(Enumerable.Select(mapping, (int index) => options[index]));
 
-            return (
-                // apply mapping to options and return it
-                Enumerable.ToArray<PickupPickerController.Option>(
-                    Enumerable.Select<int, PickupPickerController.Option>
-                        (mapping, (int index) => options[index])
-                    )
-                , 
-                // return mapping
-                mapping);
+            return (sortedOptions,mapping);
             
 
         }

--- a/LookingGlass/BasePlugin.cs
+++ b/LookingGlass/BasePlugin.cs
@@ -96,10 +96,7 @@ namespace LookingGlass
 
         private void Update()
         {
-            if (ButtonsToCloseMenu.buttonsToClickOnMove.Count != 0 && Input.anyKeyDown && !Input.GetMouseButtonDown(0))
-            {
-                ButtonsToCloseMenu.CloseMenuAfterFrame();
-            }
+            buttonsToCloseMenu.Update();
             dpsMeter.Update();
         }
         

--- a/LookingGlass/CommandItemCount/CommandItemCount.cs
+++ b/LookingGlass/CommandItemCount/CommandItemCount.cs
@@ -76,7 +76,7 @@ namespace LookingGlass.CommandItemCount
         {
             orig();
             transformedToOriginal = new();
-            foreach (var info in ContagiousItemManager.transformationInfos)
+            foreach(var info in ContagiousItemManager.transformationInfos)
             {
                 if (!transformedToOriginal.TryGetValue(info.transformedItem, out List<ItemIndex> originalItemList))
                 {

--- a/LookingGlass/CommandItemCount/CommandItemCount.cs
+++ b/LookingGlass/CommandItemCount/CommandItemCount.cs
@@ -90,20 +90,25 @@ namespace LookingGlass.CommandItemCount
         void PickupPickerPanel(Action<PickupPickerPanel, PickupPickerController.Option[]> orig, PickupPickerPanel self, PickupPickerController.Option[] options)
         {
 
-            if (isFromOnDisplayBegin && !NetworkServer.active) //Called from FromOnDisplayBegin and is a client, therefore do nothing
-            {   // as a client, PickupPickerPanel.SetPickupOptions is called twice, once from PickupPickerController.OnDisplayBegin, and once from PickupPickerController.SetOptionsInternal.
+            string parentName = self.gameObject.name;
+
+            if (isFromOnDisplayBegin && !NetworkServer.active && !parentName.StartsWith("FragmentPotentialPicker"))
+            {
+                //Called from FromOnDisplayBegin and is a client, therefore do nothing
+                // as a client, PickupPickerPanel.SetPickupOptions is called twice, once from PickupPickerController.OnDisplayBegin, and once from PickupPickerController.SetOptionsInternal.
                 // The call from OnDisplayBegin has incorrect values for the options list. It contains the list from the previous time the function was called, idk why somthing to due with networking.
+
+                //Except for the Aurelionite Fragments, they only call this function once
                 isFromOnDisplayBegin = false;
                 return;
             }
-
+                
             if (options.Length < 1)
             {
                 orig(self, options);
                 return;
             }
 
-            string parentName = self.gameObject.name;
             bool withOneMore = parentName.StartsWith("OptionPickerPanel") || parentName.StartsWith("CommandPickerPanel");
             ReadOnlyCollection<MPButton> elements = self.buttonAllocator.elements;
             Inventory inventory = LocalUserManager.GetFirstLocalUser().cachedMasterController.master.inventory;

--- a/LookingGlass/CommandItemCount/CommandItemCount.cs
+++ b/LookingGlass/CommandItemCount/CommandItemCount.cs
@@ -15,6 +15,7 @@ using RiskOfOptions;
 using RoR2.Items;
 using System.Reflection;
 using System.Linq;
+using UnityEngine.Networking;
 
 namespace LookingGlass.CommandItemCount
 {
@@ -22,10 +23,14 @@ namespace LookingGlass.CommandItemCount
     {
         private static Hook overrideHook;
         private static Hook contagiousItemsHook;
+        private static Hook submitChoiceHook;
         public static ConfigEntry<bool> commandItemCount;
         public static ConfigEntry<bool> hideCountIfZero;
         public static ConfigEntry<bool> commandToolTips;
         public static ConfigEntry<bool> showCorruptedItems;
+
+        private List<int> optionMap;
+        public bool isFromOnDisplayBegin = false;
 
         // needs to be a list because some void items corrupt multiple items
         private Dictionary<ItemIndex, List<ItemIndex>> transformedToOriginal;
@@ -42,6 +47,9 @@ namespace LookingGlass.CommandItemCount
             var targetMethod2 = typeof(ContagiousItemManager).GetMethod(nameof(ContagiousItemManager.InitTransformationTable), BindingFlags.NonPublic | BindingFlags.Static);
             var destMethod2 = typeof(CommandItemCountClass).GetMethod(nameof(InitializeTransformedToOriginal), BindingFlags.NonPublic | BindingFlags.Instance);
             contagiousItemsHook = new Hook(targetMethod2, destMethod2, this);
+            var targetMethod3 = typeof(PickupPickerController).GetMethod(nameof(PickupPickerController.SubmitChoice), BindingFlags.Public | BindingFlags.Instance);
+            var destMethod3 = typeof(CommandItemCountClass).GetMethod(nameof(SubmitChoice), BindingFlags.NonPublic | BindingFlags.Instance);
+            submitChoiceHook = new Hook(targetMethod3, destMethod3, this);
             commandItemCount = BasePlugin.instance.Config.Bind<bool>("Command Settings", "Command Item Count", true, "Shows how many items you have in the command menu");
             hideCountIfZero = BasePlugin.instance.Config.Bind<bool>("Command Settings", "Hide Count If Zero", false, "Hides the item count if you have none of an item");
             commandToolTips = BasePlugin.instance.Config.Bind<bool>("Command Settings", "Command Tooltips", true, "Shows tooltips in the command menu");
@@ -81,15 +89,30 @@ namespace LookingGlass.CommandItemCount
         //Largely copied from https://github.com/Vl4dimyr/CommandItemCount/blob/master/CommandItemCountPlugin.cs#L191
         void PickupPickerPanel(Action<PickupPickerPanel, PickupPickerController.Option[]> orig, PickupPickerPanel self, PickupPickerController.Option[] options)
         {
-            orig(self, options);
-            if (options.Length < 1)
-            {
+
+            if (isFromOnDisplayBegin && !NetworkServer.active) //Called from FromOnDisplayBegin and is a client, therefore do nothing
+            {   // as a client, PickupPickerPanel.SetPickupOptions is called twice, once from PickupPickerController.OnDisplayBegin, and once from PickupPickerController.SetOptionsInternal.
+                // The call from OnDisplayBegin has incorrect values for the options list. It contains the list from the previous time the function was called, idk why somthing to due with networking.
+                isFromOnDisplayBegin = false;
                 return;
             }
+
+            if (options.Length < 1)
+            {
+                orig(self, options);
+                return;
+            }
+
             string parentName = self.gameObject.name;
             bool withOneMore = parentName.StartsWith("OptionPickerPanel") || parentName.StartsWith("CommandPickerPanel");
             ReadOnlyCollection<MPButton> elements = self.buttonAllocator.elements;
             Inventory inventory = LocalUserManager.GetFirstLocalUser().cachedMasterController.master.inventory;
+            
+            // sort the options and record sorting map. Sorting map is used later to make sure the correct item is scrapped/selected when clicking the corrosponding item button.
+            (options, optionMap) = BasePlugin.instance.autoSortItems.SortPickupPicker(options, self.name.StartsWith("CommandCube"));
+
+            orig(self, options);
+
             for (int i = 0; i < options.Length; i++)
             {
                 ItemIndex itemIndex = PickupCatalog.GetPickupDef(options[i].pickupIndex).itemIndex;
@@ -138,6 +161,19 @@ namespace LookingGlass.CommandItemCount
                     CreateToolTip(elements[i].transform, PickupCatalog.GetPickupDef(options[i].pickupIndex), count, withOneMore, corruption);
             }
         }
+
+        private void SubmitChoice(Action<PickupPickerController, int> orig, PickupPickerController self, int index)
+        {
+            // change selected option based on option map
+            // if the first element in optionMap < 0 , the options were never sorted
+            int newIndex = (optionMap[0] >= 0) ? optionMap[index] : index;
+            
+            //Log.Debug($"Pressed {index}, Redirected {newIndex}");
+
+            orig(self, newIndex);
+        }
+
+
         void CreateNumber(Transform parent, int count, ItemCorruptionInfo corruption)
         {
             GameObject textContainer = new GameObject();

--- a/LookingGlass/CommandWindowBlur/NoWindowBlur.cs
+++ b/LookingGlass/CommandWindowBlur/NoWindowBlur.cs
@@ -41,21 +41,11 @@ namespace LookingGlass.CommandWindowBlur
         }
         void OnDisplayBegin(Action<RoR2.PickupPickerController, NetworkUIPromptController, LocalUser, CameraRigController> orig, RoR2.PickupPickerController self, NetworkUIPromptController networkUIPromptController, LocalUser localUser, CameraRigController cameraRigController)
         {
+
+            BasePlugin.instance.commandItemCountClass.isFromOnDisplayBegin = true; // tell the scrapper sorting that it was called from OnDisplayBegin
+
             orig(self, networkUIPromptController, localUser, cameraRigController);
-            try
-            {
-                if (self.name.StartsWith("CommandCube") || self.name.StartsWith("Scrapper"))
-                {
-                    ReadOnlyCollection<MPButton> elements = self.panelInstanceController.buttonAllocator.elements;
-                    Inventory inventory = LocalUserManager.GetFirstLocalUser().cachedMasterController.master.inventory;
-                    BasePlugin.instance.autoSortItems.SortPickupPicker(self.options, elements, inventory, self.name.StartsWith("CommandCube"), self.panelInstanceController);
-                }
-            }
-            catch (Exception)
-            {
-                Log.Debug($"couldn't sort items");
-                return;
-            }
+
             TranslucentImage t = self.panelInstance.gameObject.GetComponentInChildren<TranslucentImage>();
             if (t is not null)
             {

--- a/LookingGlass/CommandWindowBlur/NoWindowBlur.cs
+++ b/LookingGlass/CommandWindowBlur/NoWindowBlur.cs
@@ -41,8 +41,7 @@ namespace LookingGlass.CommandWindowBlur
         }
         void OnDisplayBegin(Action<RoR2.PickupPickerController, NetworkUIPromptController, LocalUser, CameraRigController> orig, RoR2.PickupPickerController self, NetworkUIPromptController networkUIPromptController, LocalUser localUser, CameraRigController cameraRigController)
         {
-
-            BasePlugin.instance.commandItemCountClass.isFromOnDisplayBegin = true; // tell the scrapper sorting that it was called from OnDisplayBegin
+            BasePlugin.instance.commandItemCountClass.OnDisplayBeginStuff(); // needs to be for orig() inorder to set up option menu sorting correctly
 
             orig(self, networkUIPromptController, localUser, cameraRigController);
 

--- a/LookingGlass/CommandWindowBlur/NoWindowBlur.cs
+++ b/LookingGlass/CommandWindowBlur/NoWindowBlur.cs
@@ -41,7 +41,7 @@ namespace LookingGlass.CommandWindowBlur
         }
         void OnDisplayBegin(Action<RoR2.PickupPickerController, NetworkUIPromptController, LocalUser, CameraRigController> orig, RoR2.PickupPickerController self, NetworkUIPromptController networkUIPromptController, LocalUser localUser, CameraRigController cameraRigController)
         {
-            BasePlugin.instance.commandItemCountClass.OnDisplayBeginStuff(); // needs to be for orig() inorder to set up option menu sorting correctly
+            BasePlugin.instance.commandItemCountClass.OnDisplayBeginStuff(); // needs to before orig() inorder to set up option menu sorting correctly
 
             orig(self, networkUIPromptController, localUser, cameraRigController);
 

--- a/LookingGlass/EscapeToCloseMenu/ButtonsToCloseMenu.cs
+++ b/LookingGlass/EscapeToCloseMenu/ButtonsToCloseMenu.cs
@@ -70,12 +70,12 @@ namespace LookingGlass.EscapeToCloseMenu
                 CloseMenuAfterFrame();
             }
 
-            if (interactHoldBlocker && (!LocalUserManager.GetFirstLocalUser().inputPlayer.GetButton(5) || Time.time >= holdBlockerStartTime + 0.5)) //if blocker is active and  player is not holding interact
-            {
-
+            // Interact hold blocker to prevent rappidly opening/closing menu because that breaks the menu
+            if (interactHoldBlocker && (!LocalUserManager.GetFirstLocalUser().inputPlayer.GetButton(5) || Time.time >= holdBlockerStartTime + 0.5))
+            {//if blocker is active and  player is not holding interact or it has been more than 0.5 seconds
                 interactHoldBlocker = false; //turn off blocker
                 
-                if (pickupPickerController != null) // the command menu destorys the pickupPickerController before thus runs, so must check if it is null
+                if (pickupPickerController != null) // the command menu destroys the pickupPickerController before thus runs, so must check if it is null
                 {
                     pickupPickerController.enabled = true;
                     // toggle the pickupPickerController like this and not with PickupPickerController.available because this way isnt networked, and the networking is what was causing issues
@@ -93,7 +93,7 @@ namespace LookingGlass.EscapeToCloseMenu
                     buttonsToClickOnMove[0].InvokeClick();
                     interactHoldBlocker = true;
 
-                    if (pickupPickerController != null) // the command menu destorys the pickupPickerController before thus runs, so must check if it is null
+                    if (pickupPickerController != null) // the command menu destroys the pickupPickerController before thus runs, so must check if it is null
                     {
                         pickupPickerController.enabled = false;
                         // toggle the pickupPickerController like this and not with PickupPickerController.available because this way isnt networked, and the networking is what was causing issues

--- a/LookingGlass/EscapeToCloseMenu/ButtonsToCloseMenu.cs
+++ b/LookingGlass/EscapeToCloseMenu/ButtonsToCloseMenu.cs
@@ -62,7 +62,7 @@ namespace LookingGlass.EscapeToCloseMenu
             }
         }
 
-        public void HandleMenuClose()
+        public void Update()
         {
 
             if (buttonsToClickOnMove.Count != 0 && Input.anyKeyDown && !Input.GetMouseButtonDown(0))

--- a/LookingGlass/LookingGlass.csproj
+++ b/LookingGlass/LookingGlass.csproj
@@ -24,7 +24,7 @@
     </PackageReference>
     <PackageReference Include="BepInEx.Core" Version="5.4.21" />
     <PackageReference Include="BepInEx.PluginInfoProps" Version="1.*" />
-    <PackageReference Include="RiskOfRain2.GameLibs" Version="1.3.6-r.0" publicize="true"  />
+	<PackageReference Include="RiskOfRain2.GameLibs" Version="1.3.8-r.0" publicize="true"/>
     <PackageReference Include="UnityEngine.Modules" Version="2021.3.33" />
     <PackageReference Include="Rune580.Mods.RiskOfRain2.RiskOfOptions" Version="2.7.2" />
   </ItemGroup>

--- a/LookingGlass/StatsDisplay/StatsDisplayDefinitions.cs
+++ b/LookingGlass/StatsDisplay/StatsDisplayDefinitions.cs
@@ -97,7 +97,7 @@ namespace LookingGlass.StatsDisplay
             });
             StatsDisplayClass.statDictionary.Add("dps", cachedUserBody => { return $"{damageString}{BasePlugin.instance.dpsMeter.damageDealtSincePeriod / DPSMeter.DPS_MAX_TIME}{styleString}"; });
             StatsDisplayClass.statDictionary.Add("percentDps", cachedUserBody
-                => $"{damageString}{(BasePlugin.instance.dpsMeter.damageDealtSincePeriod / cachedUserBody.damageFromRecalculateStats / DPSMeter.DPS_MAX_TIME).ToString(floatPrecision)}{styleString}");
+                => $"{damageString}{(BasePlugin.instance.dpsMeter.damageDealtSincePeriod / cachedUserBody.damage / DPSMeter.DPS_MAX_TIME).ToString(floatPrecision)}{styleString}");
             StatsDisplayClass.statDictionary.Add("currentCombatDamage", cachedUserBody => { return $"{damageString}{BasePlugin.instance.dpsMeter.currentCombatDamage}{styleString}"; });
             StatsDisplayClass.statDictionary.Add("remainingComboDuration", cachedUserBody => { return $"{utilityString}{(int)BasePlugin.instance.dpsMeter.timer + 1}{styleString}"; });
             StatsDisplayClass.statDictionary.Add("maxCombo", cachedUserBody => { return $"{damageString}{BasePlugin.instance.dpsMeter.maxCombo}{styleString}"; });


### PR DESCRIPTION
Move where the sorting takes place for PickupPickerPanel from RoR2.PickupPickerController.OnDisplayBegin to RoR2.UI.PickupPickerPanel.SetPickupOptions because in multiplayer there is a lot of weirdness. This fixes bug https://github.com/Wet-Boys/LookingGlass/issues/65

As a client in multiplayer when OnDisplayBegin is called the Options list will be (effectively) garbage data leftover from the previous time a PickupPickerPanel was opened. As a client, SetPickupOptions is called twice when opening a scrapper/command, the first time from OnDisplayBegin, and the 2nd time from other netcode. The first call will contain garbage data, the 2nd will have correct data. This behavior is only true in multiplayer, in singleplayer SetPickupOptions is only called once.

Because of these changes, Ror2.PickupPickerController.SubmitChoice also has to be hooked so the correct item is scrapped/selected when choosing an item. The only data sent when selecting an item is its position in the Options list. When the Options are sorted their order in the list changes so the changes must be un-done when sending the data back to the host. 

I also added logic to prevent the scrapper/command menu from re-opening if you press Interact to close it.

I have tested these changes with friends for a couple months and they seem functional (although it was mainly testing scrappers, I did not test command as much)