### PR TITLE
send it

### DIFF
--- a/LookingGlass/AutoSortItems/AutoSortItemsClass.cs
+++ b/LookingGlass/AutoSortItems/AutoSortItemsClass.cs
@@ -55,6 +55,10 @@ namespace LookingGlass.AutoSortItems
         public static ConfigEntry<bool> SortCommandAlphabeticalDescending;
         public static ConfigEntry<bool> SortScrapperAlphabeticalDescending;
 
+        public static ConfigEntry<bool> SortPotentials;
+        public static ConfigEntry<bool> SortDeathScreen;
+
+
         public static AutoSortItemsClass instance;
         RoR2.UI.ItemInventoryDisplay display;
         List<List<ItemIndex>> itemTierLists = new List<List<ItemIndex>>();
@@ -82,7 +86,6 @@ namespace LookingGlass.AutoSortItems
             SortScrapper = BasePlugin.instance.Config.Bind<bool>("Auto Sort Items", "Sort Scrapper", true, "Sorts Scrapper by stack count");
             SortScrapperDescending = BasePlugin.instance.Config.Bind<bool>("Auto Sort Items", "Scrapper Descending", true, "Sorts Scrapper by descending");
             SortScrapperTier = BasePlugin.instance.Config.Bind<bool>("Auto Sort Items", "Sort Scrapper Tier", false, "Sorts Scrapper by tier");
-
             SortCommandAlphabetical = BasePlugin.instance.Config.Bind<bool>("Auto Sort Items", "Sort Command Menu Alphabetically", false, "Sorts command menu alphabetically");
             SortCommandAlphabeticalDescending = BasePlugin.instance.Config.Bind<bool>("Auto Sort Items", "Command Menu Alphabetically Descending", true, "Sorts command alphabetically descending");
             SortScrapperAlphabetical = BasePlugin.instance.Config.Bind<bool>("Auto Sort Items", "Sort Scrapper Alphabetically", false, "Sorts Scrapper alphabetically");
@@ -94,6 +97,10 @@ namespace LookingGlass.AutoSortItems
             SortByStackSize.SettingChanged += SettingsChanged;
             DescendingStackSize.SettingChanged += SettingsChanged;
 
+            //
+            SortPotentials = BasePlugin.instance.Config.Bind<bool>("Auto Sort Items", "Sort Potentials & Fragments", false, "Sorts Void Potentials & Aurelionite Fragments according to Scrapper rules.");
+            SortDeathScreen = BasePlugin.instance.Config.Bind<bool>("Auto Sort Items", "Sort Death Screen & Monster Items", false, "Sort items on the game over screen, in run reports, or in Monster Inventories such as Evolution.");
+            //
             InitHooks();
             SetupRiskOfOptions();
         }
@@ -119,6 +126,10 @@ namespace LookingGlass.AutoSortItems
             ModSettingsManager.AddOption(new CheckBoxOption(SortCommandAlphabeticalDescending, new CheckBoxConfig() { restartRequired = false, checkIfDisabled = CheckCommandSortAlphabetical }));
             ModSettingsManager.AddOption(new CheckBoxOption(SortScrapperAlphabetical, new CheckBoxConfig() { restartRequired = false }));
             ModSettingsManager.AddOption(new CheckBoxOption(SortScrapperAlphabeticalDescending, new CheckBoxConfig() { restartRequired = false, checkIfDisabled = CheckScrapperSortTierAlphabetical }));
+
+            ModSettingsManager.AddOption(new CheckBoxOption(SortPotentials, new CheckBoxConfig() { restartRequired = false}));
+            ModSettingsManager.AddOption(new CheckBoxOption(SortDeathScreen, new CheckBoxConfig() { restartRequired = false }));
+
         }
         //I'm going cross-eyed looking at all these
         private static bool CheckTierSort()
@@ -288,7 +299,11 @@ namespace LookingGlass.AutoSortItems
         }
         private void UpdateDisplayOverride(Action<RoR2.UI.ItemInventoryDisplay> orig, RoR2.UI.ItemInventoryDisplay self)
         {
-            if (self != null)
+            //If inventory is null is a good check to see if it's a GameOver or RunReport Inventory.
+            //Because there the items are added manually
+            //However would also prevent sorting of enemy items. (Vields, Evo)
+            //I am unaware of a better check atm
+            if (self != null && (self.inventory != null || SortDeathScreen.Value))
             {
                 display = self;
                 var temp = self.itemOrder;

--- a/LookingGlass/BasePlugin.cs
+++ b/LookingGlass/BasePlugin.cs
@@ -73,13 +73,15 @@ namespace LookingGlass
             }
 
 
+            statsDisplayClass = new StatsDisplayClass(); //More important config to have in first slot?
+
             autoSortItems = new AutoSortItemsClass();
             noWindowBlur = new NoWindowBlur();
             buttonsToCloseMenu = new ButtonsToCloseMenu();
             hidePickupNotifications = new HidePickupNotifications();
             commandItemCountClass = new CommandItemCountClass();
             resizeCommandWindowClass = new ModifyCommandWindow();
-            statsDisplayClass = new StatsDisplayClass();
+            
             buffTimers = new BuffTimersClass();
             dpsMeter = new DPSMeter();
             itemCounter = new ItemCounter();

--- a/LookingGlass/BuffDescriptions/BuffDescriptions.cs
+++ b/LookingGlass/BuffDescriptions/BuffDescriptions.cs
@@ -65,6 +65,11 @@ namespace LookingGlass.BuffDescriptions
                 TooltipProvider toolTip = self.GetComponent<TooltipProvider>();
                 if (!toolTip)
                 {
+                    if (self.GetComponentInParent<Canvas>() == null)
+                    {
+                        //Issue with disabled Huds tht can go on forever
+                        return;
+                    }
                     if (!self.GetComponentInParent<Canvas>().gameObject.GetComponent<GraphicRaycaster>())
                     {
                         self.GetComponentInParent<Canvas>().gameObject.AddComponent<GraphicRaycaster>();

--- a/LookingGlass/BuffTimers/BuffTimersClass.cs
+++ b/LookingGlass/BuffTimers/BuffTimersClass.cs
@@ -56,7 +56,7 @@ namespace LookingGlass.BuffTimers
                             TextMeshProUGUI item = buffIcon.buffIconComponent.GetComponentInChildren<TextMeshProUGUI>();
                             item.enabled = true;
                             item.text = $"<size={buffTimersFontSize.Value}%>{(timedBuff.timer):0.0}</size>\n";
-                            if (buffIcon.buffCount > 1)
+                            if (buffIcon.buffDef.canStack && buffIcon.buffCount > 1)
                             {
                                 item.text += $"x{buffIcon.buffCount}";
                             }

--- a/LookingGlass/CommandItemCount/CommandItemCount.cs
+++ b/LookingGlass/CommandItemCount/CommandItemCount.cs
@@ -16,6 +16,7 @@ using RoR2.Items;
 using System.Reflection;
 using System.Linq;
 using UnityEngine.Networking;
+using LookingGlass.AutoSortItems;
 
 namespace LookingGlass.CommandItemCount
 {
@@ -102,13 +103,23 @@ namespace LookingGlass.CommandItemCount
                 return;
             }
 
+            bool potentialOrFragment = false;
+            if (self.pickerController)
+            {
+                potentialOrFragment = self.pickerController.GetComponent<PickupIndexNetworker>(); //Good enough
+                //Both Fragments and Potentials would have a pickup
+            }
+
             string parentName = self.gameObject.name;
             bool withOneMore = parentName.StartsWith("OptionPickerPanel") || parentName.StartsWith("CommandPickerPanel");
             ReadOnlyCollection<MPButton> elements = self.buttonAllocator.elements;
             Inventory inventory = LocalUserManager.GetFirstLocalUser().cachedMasterController.master.inventory;
 
             // sort the options and record sorting map. Sorting map is used later to make sure the correct item is scrapped/selected when clicking the corrosponding item button.
-            (options, optionMap) = BasePlugin.instance.autoSortItems.SortPickupPicker(options, self.name.StartsWith("CommandCube"));
+            if (!potentialOrFragment || AutoSortItemsClass.SortPotentials.Value)
+            {
+                (options, optionMap) = BasePlugin.instance.autoSortItems.SortPickupPicker(options, self.name.StartsWith("CommandCube"));
+            }
 
             orig(self, options);
 

--- a/LookingGlass/ItemStats/ItemDefinitions.cs
+++ b/LookingGlass/ItemStats/ItemDefinitions.cs
@@ -40,6 +40,7 @@ namespace LookingGlass.ItemStatsNameSpace
 
             
             //Elusive Antlers (Previously Antler Shield)
+            //Changed to 3 per stack from 3 + 1
             itemStat = new ItemStatsDef();
             itemStat.descriptions.Add("Min Bonus Movement Speed: ");
             itemStat.valueTypes.Add(ItemStatsDef.ValueType.Utility);
@@ -55,7 +56,7 @@ namespace LookingGlass.ItemStatsNameSpace
                 List<float> values = new();
                 values.Add(.07f * stackCount);
                 values.Add(10f - ((1f - 3f / (3f + (float)stackCount - 1f)) * 5f));
-                values.Add(2 + stackCount);
+                values.Add(3 * stackCount);
                 return values;
             };
             allItemDefinitions.Add((int)DLC2Content.Items.SpeedBoostPickup.itemIndex, itemStat);
@@ -104,18 +105,23 @@ namespace LookingGlass.ItemStatsNameSpace
 
             
             //Bolstering Lantern
+            //Changed to no longer increase Radius
             itemStat = new ItemStatsDef();
+            itemStat.descriptions.Add("Attack Speed Per Nearby: ");
+            itemStat.valueTypes.Add(ItemStatsDef.ValueType.Damage);
+            itemStat.measurementUnits.Add(ItemStatsDef.MeasurementUnits.Percentage);
             itemStat.descriptions.Add("Max Attack Speed: ");
             itemStat.valueTypes.Add(ItemStatsDef.ValueType.Damage);
             itemStat.measurementUnits.Add(ItemStatsDef.MeasurementUnits.Percentage);
-            itemStat.descriptions.Add("Range: ");
+            itemStat.descriptions.Add("Max Buff Count: ");
             itemStat.valueTypes.Add(ItemStatsDef.ValueType.Utility);
             itemStat.measurementUnits.Add(ItemStatsDef.MeasurementUnits.Meters);
             itemStat.calculateValuesNew = (luck, stackCount, procChance) =>
             {
                 List<float> values = new();
-                values.Add(.15f + (.15f * stackCount));
-                values.Add(15 + (5 * stackCount));
+                values.Add(.065f + (.035f * stackCount));
+                values.Add((.65f + (.035f * stackCount))*(2+ stackCount));
+                values.Add(2 +stackCount);
                 return values;
             };
             allItemDefinitions.Add((int)DLC2Content.Items.AttackSpeedPerNearbyAllyOrEnemy.itemIndex, itemStat);
@@ -1328,17 +1334,14 @@ namespace LookingGlass.ItemStatsNameSpace
             
             
             //Growth Nectar
+            //Removed stacking -> Increasing Stats per buff
             itemStat = new ItemStatsDef();
-            itemStat.descriptions.Add("Stats Per Stack: ");
-            itemStat.valueTypes.Add(ItemStatsDef.ValueType.Utility);
-            itemStat.measurementUnits.Add(ItemStatsDef.MeasurementUnits.Percentage);
             itemStat.descriptions.Add("Max Stacks: ");
             itemStat.valueTypes.Add(ItemStatsDef.ValueType.Utility);
             itemStat.measurementUnits.Add(ItemStatsDef.MeasurementUnits.Number);
             itemStat.calculateValuesNew = (luck, stackCount, procChance) =>
             {
                 List<float> values = new();
-                values.Add(0.04f * stackCount);
                 values.Add(4 * stackCount);
                 return values;
             };

--- a/LookingGlass/StatsDisplay/StatsDisplayDefinitions.cs
+++ b/LookingGlass/StatsDisplay/StatsDisplayDefinitions.cs
@@ -47,9 +47,9 @@ namespace LookingGlass.StatsDisplay
             StatsDisplayClass.statDictionary.Add("mountainShrines", cachedUserBody => { return $"{utilityString}{((TeleporterInteraction.instance is not null ? TeleporterInteraction.instance.shrineBonusStacks : "N/A"))}{styleString}"; });
             StatsDisplayClass.statDictionary.Add("experience", cachedUserBody => { return $"{utilityString}{(cachedUserBody.experience).ToString(floatPrecision)}{styleString}"; });
             StatsDisplayClass.statDictionary.Add("level", cachedUserBody => { return $"{utilityString}{(cachedUserBody.level)}{styleString}"; });
-            StatsDisplayClass.statDictionary.Add("maxHealth", cachedUserBody => { return $"{healthString}{(cachedUserBody.maxHealth)}{styleString}"; });
-            StatsDisplayClass.statDictionary.Add("maxBarrier", cachedUserBody => { return $"{utilityString}{(cachedUserBody.maxBarrier)}{styleString}"; });
-            StatsDisplayClass.statDictionary.Add("barrierDecayRate", cachedUserBody => { return $"{utilityString}{(cachedUserBody.barrierDecayRate).ToString(floatPrecision)}{styleString}"; });
+            StatsDisplayClass.statDictionary.Add("maxHealth", cachedUserBody => { return $"{healingString}{(cachedUserBody.maxHealth)}{styleString}"; });
+            StatsDisplayClass.statDictionary.Add("maxBarrier", cachedUserBody => { return $"{healingString}{(cachedUserBody.maxBarrier)}{styleString}"; });
+            StatsDisplayClass.statDictionary.Add("barrierDecayRate", cachedUserBody => { return $"{healingString}{(cachedUserBody.barrierDecayRate).ToString(floatPrecision)}{styleString}"; });
             StatsDisplayClass.statDictionary.Add("maxShield", cachedUserBody => { return $"{utilityString}{(cachedUserBody.maxShield)}{styleString}"; });
             StatsDisplayClass.statDictionary.Add("acceleration", cachedUserBody => { return $"{utilityString}{(cachedUserBody.acceleration).ToString(floatPrecision)}{styleString}"; });
             StatsDisplayClass.statDictionary.Add("jumpPower", cachedUserBody => { return $"{utilityString}{(cachedUserBody.jumpPower).ToString(floatPrecision)}{styleString}"; });


### PR DESCRIPTION
General update to mod featuring some stuff that was lacking from BetterUI, or getting rid of some excessive things.


```
----Looking Glass Stuff----- 

No longer sorts on Death End Screen/Run Report
->Because there you wanna show ItemAquisitionorder.
->Config to renable
->Side effect is that 'Monster Items' no longer get sorted, not sure how to have a better check
No longer sorts Void Potentials & Aurelionite Fragments.
->Config to renable
->I think it looks & feels better if they're not sorted
->Just reusing Scrapper Config values atm

--Stat Display--

Added Stat Display Presets.
->Good to have presets because making a stat display yourself can be overwhelming

(From Default Stat Display stat string)
Removed Luck stat.
->Not important, not a real stat it's just 2 items.

Removed Combo Timer
->I think people who care about Combos will get the 5s timer in their head.
->And if they dont it's just another thing on screen
->But the prests would have a ComboLess version anyways ig.

Changed maxCombo to maxComboPerRun 
->The ugliest part of the mod, having this stuck at a giant number on screen, at all times.


Reduced default size to 14. (From 16) 
->The average between 'Objective Header' and 'Objective Content'
->Because making each individual stat as big as the header takes up too much space.


Added Margin to default stat strings/presets to match padding of Objectives./Better fit into right side info.

Moved "purchase/inspect" text left so it doesn't clip into Stat Display.
->It's ugly to have it clip into it (and the previous default settings do that)
->Config to put back


---

Moved around some config.
Moved StatDisplay config first in RiskOfOptions.
->When editing it it's one less click so it feels nicer
->Arguably main part of mod so should be first?


Updated Elusive Antler, Growth Nectar, Bolstering Lantern stats to match updates they got.
Changed Health/Barrier numbers to Green. (Red is used as Hurt not Health and Barrier is generally Healing not Utility)

Fixed unstackable timed buffs showing stacks.
Fixed an issue with disabling Huds and Buff Icons.
 
```