### PR TITLE
Fix incompatibility with RiskUI

### DIFF
--- a/LookingGlass/ItemStats/AllyCardInfo.cs
+++ b/LookingGlass/ItemStats/AllyCardInfo.cs
@@ -56,8 +56,10 @@ namespace LookingGlass
             orig(self);
             // Is it more optimized to have more hooks (ie do this in awake)
             // Or less hooks but some redundency
-            self.GetComponent<Image>().raycastTarget = true;
-
+            if (self.TryGetComponent<Image>(out Image card))
+            {
+                card.raycastTarget = true;
+            }
         }
 
         public void AddAllyTooltips(Action<AllyCardController> orig, AllyCardController self)


### PR DESCRIPTION
RiskUI removes the background graphic on ally cards.

A null-check and skip is sufficient, since the graphic elements in RiskUI's ally cards (e.g. portrait icon, health text, name) already have `raycastTarget` set to true.

----

Resolves #206, Bubbet/Risk-Of-Rain-Mods#138, and (partially?) Bubbet/Risk-Of-Rain-Mods#137